### PR TITLE
feat(utils): add utils module and wire up root index

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,11 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "globals": {
+    "URL": "readonly",
+    "URLSearchParams": "readonly",
+    "Response": "readonly",
+    "fetch": "readonly"
+  },
   "rules": {
     "no-console": "warn",
     "no-debugger": "error",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "nodejs-library-template",
+  "name": "bcch",
   "version": "0.0.1",
-  "description": "",
-  "homepage": "https://github.com/airarrazaval/nodejs-library-template#readme",
+  "description": "Node.js wrapper for the Banco Central de Chile API. Features a fully typed API client and utility tools to streamline macroeconomic data integration.",
+  "homepage": "https://github.com/airarrazaval/bcch#readme",
   "bugs": {
-    "url": "https://github.com/airarrazaval/nodejs-library-template/issues"
+    "url": "https://github.com/airarrazaval/bcch/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/airarrazaval/nodejs-library-template.git"
+    "url": "https://github.com/airarrazaval/bcch.git"
   },
   "files": [
     "dist",
@@ -24,6 +24,21 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
+    },
+    "./series": {
+      "types": "./dist/series/index.d.ts",
+      "import": "./dist/series/index.js",
+      "default": "./dist/series/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js",
+      "default": "./dist/utils/index.js"
     }
   },
   "scripts": {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,0 +1,186 @@
+import { ApiError, HttpError } from './types.js';
+import type {
+  ClientOptions,
+  Frequency,
+  GetSeriesOptions,
+  Observation,
+  SeriesData,
+  SeriesInfo,
+} from './types.js';
+
+const API_URL = 'https://si3.bcentral.cl/SieteRestWS/SieteRestWS.ashx';
+
+// Raw shapes returned by the wire — not part of the public API.
+interface RawObservation {
+  indexDateString: string;
+  value: string;
+  statusCode: string;
+}
+
+interface RawGetSeriesResponse {
+  Codigo: number;
+  Descripcion: string;
+  Series: {
+    descripEsp: string;
+    descripIng: string;
+    seriesId: string;
+    Obs: RawObservation[];
+  } | null;
+  SeriesInfos: null;
+}
+
+interface RawSeriesInfo {
+  seriesId: string;
+  frequencyCode: string;
+  spanishTitle: string;
+  englishTitle: string;
+  firstObservation: string;
+  lastObservation: string;
+  updatedAt: string;
+  createdAt: string;
+}
+
+interface RawSearchSeriesResponse {
+  Codigo: number;
+  Descripcion: string;
+  Series: null;
+  SeriesInfos: RawSeriesInfo[] | null;
+}
+
+/**
+ * HTTP client for the Banco Central de Chile REST API.
+ *
+ * @example
+ * ```ts
+ * import { Client } from 'bcch/client';
+ *
+ * const client = new Client({ user: 'me@example.com', pass: 'secret' });
+ * const data = await client.getSeries('F022.TPM.TIN.D001.NO.Z.D', {
+ *   firstdate: '2024-01-01',
+ * });
+ * console.log(data.observations);
+ * ```
+ */
+export class Client {
+  private readonly user: string;
+  private readonly pass: string;
+  private readonly fetch: typeof globalThis.fetch;
+
+  constructor(options: ClientOptions) {
+    this.user = options.user;
+    this.pass = options.pass;
+    this.fetch = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Fetches observations for a single time series.
+   *
+   * @param seriesId - BCCH series identifier (e.g. `'F022.TPM.TIN.D001.NO.Z.D'`).
+   *   Values from the `SERIES` constants in `bcch/series` are accepted directly.
+   * @param options - Optional date range filter.
+   * @returns Parsed series data including all observations in the requested range.
+   * @throws {ApiError} When the API returns a non-zero `Codigo`.
+   * @throws {HttpError} When the API returns a non-ok HTTP status.
+   * @throws {Error} When a network failure occurs; original error is set as `cause`.
+   *
+   * @example
+   * ```ts
+   * const data = await client.getSeries('F073.UFF.PRE.Z.D', {
+   *   firstdate: '2024-01-01',
+   *   lastdate: '2024-12-31',
+   * });
+   * ```
+   */
+  async getSeries(seriesId: string, options?: GetSeriesOptions): Promise<SeriesData> {
+    const params = this.baseParams();
+    params.set('function', 'GetSeries');
+    params.set('timeseries', seriesId);
+    if (options?.firstdate !== undefined) {
+      params.set('firstdate', options.firstdate);
+    }
+    if (options?.lastdate !== undefined) {
+      params.set('lastdate', options.lastdate);
+    }
+
+    const raw = await this.request<RawGetSeriesResponse>(params);
+
+    if (raw.Codigo !== 0 || raw.Series === null) {
+      throw new ApiError(`BCCH API error: ${raw.Descripcion}`, raw.Codigo, raw.Descripcion);
+    }
+
+    const observations: Observation[] = raw.Series.Obs.map((obs) => ({
+      indexDateString: obs.indexDateString,
+      value: obs.value,
+      statusCode: obs.statusCode,
+    }));
+
+    return {
+      seriesId: raw.Series.seriesId,
+      descripEsp: raw.Series.descripEsp,
+      descripIng: raw.Series.descripIng,
+      observations,
+    };
+  }
+
+  /**
+   * Searches for available series filtered by observation frequency.
+   *
+   * @param frequency - One of `'DAILY'`, `'MONTHLY'`, `'QUARTERLY'`, or `'ANNUAL'`.
+   * @returns Array of series metadata matching the given frequency.
+   * @throws {ApiError} When the API returns a non-zero `Codigo`.
+   * @throws {HttpError} When the API returns a non-ok HTTP status.
+   * @throws {Error} When a network failure occurs; original error is set as `cause`.
+   *
+   * @example
+   * ```ts
+   * const monthlySeries = await client.searchSeries('MONTHLY');
+   * console.log(monthlySeries.map(s => s.englishTitle));
+   * ```
+   */
+  async searchSeries(frequency: Frequency): Promise<SeriesInfo[]> {
+    const params = this.baseParams();
+    params.set('function', 'SearchSeries');
+    params.set('frequency', frequency);
+
+    const raw = await this.request<RawSearchSeriesResponse>(params);
+
+    if (raw.Codigo !== 0) {
+      throw new ApiError(`BCCH API error: ${raw.Descripcion}`, raw.Codigo, raw.Descripcion);
+    }
+
+    return (raw.SeriesInfos ?? []).map((info) => ({
+      seriesId: info.seriesId,
+      frequencyCode: info.frequencyCode,
+      spanishTitle: info.spanishTitle,
+      englishTitle: info.englishTitle,
+      firstObservation: info.firstObservation,
+      lastObservation: info.lastObservation,
+      updatedAt: info.updatedAt,
+      createdAt: info.createdAt,
+    }));
+  }
+
+  private baseParams(): URLSearchParams {
+    const params = new URLSearchParams();
+    params.set('user', this.user);
+    params.set('pass', this.pass);
+    return params;
+  }
+
+  private async request<T>(params: URLSearchParams): Promise<T> {
+    const url = `${API_URL}?${params.toString()}`;
+    let response: Response;
+
+    try {
+      response = await this.fetch(url);
+    } catch (err) {
+      throw new Error('BCCH request failed', { cause: err });
+    }
+
+    if (!response.ok) {
+      throw new HttpError(`HTTP error ${response.status}`, response.status);
+    }
+
+    return response.json() as Promise<T>;
+  }
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,10 @@
+export { Client } from './client.js';
+export { ApiError, HttpError } from './types.js';
+export type {
+  ClientOptions,
+  Frequency,
+  GetSeriesOptions,
+  Observation,
+  SeriesData,
+  SeriesInfo,
+} from './types.js';

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,173 @@
+/**
+ * Credentials and configuration for {@link Client}.
+ */
+export interface ClientOptions {
+  /** BCCH account email. */
+  user: string;
+
+  /** BCCH account password. */
+  pass: string;
+
+  /**
+   * HTTP client used for all requests.
+   *
+   * Defaults to the global `fetch`. Inject a custom implementation in tests
+   * to avoid real network calls.
+   *
+   * @defaultValue `globalThis.fetch`
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * A single observation returned by the BCCH API.
+ *
+ * Dates are in the wire format `"DD-MM-YYYY"` as returned by the API.
+ * Values are raw numeric strings; an empty string indicates a data gap.
+ * Use {@link https://github.com/airarrazaval/bcch | bcch/utils} to parse
+ * and transform observations.
+ */
+export interface Observation {
+  /** Observation date in `"DD-MM-YYYY"` format. */
+  indexDateString: string;
+
+  /**
+   * Numeric value as a string.
+   *
+   * An empty string (`""`) indicates a gap in the series (no observation
+   * for that date). Use `parseValue` from `bcch/utils` to convert to a
+   * `number | null`.
+   */
+  value: string;
+
+  /** Observation status code (e.g. `"OK"`, `"NO_OBS"`). */
+  statusCode: string;
+}
+
+/**
+ * Time series data returned by {@link Client.getSeries}.
+ */
+export interface SeriesData {
+  /** BCCH series identifier. */
+  seriesId: string;
+
+  /** Series description in Spanish. */
+  descripEsp: string;
+
+  /** Series description in English. */
+  descripIng: string;
+
+  /** Ordered array of observations, earliest first. */
+  observations: Observation[];
+}
+
+/**
+ * Date range filter for {@link Client.getSeries}.
+ */
+export interface GetSeriesOptions {
+  /**
+   * Start date in `"YYYY-MM-DD"` format.
+   *
+   * Defaults to the earliest available observation when omitted.
+   */
+  firstdate?: string;
+
+  /**
+   * End date in `"YYYY-MM-DD"` format.
+   *
+   * Defaults to the most recent available observation when omitted.
+   */
+  lastdate?: string;
+}
+
+/**
+ * Metadata for a single series returned by {@link Client.searchSeries}.
+ */
+export interface SeriesInfo {
+  /** BCCH series identifier. */
+  seriesId: string;
+
+  /** Frequency code (e.g. `"DAILY"`, `"MONTHLY"`). */
+  frequencyCode: string;
+
+  /** Series title in Spanish. */
+  spanishTitle: string;
+
+  /** Series title in English. */
+  englishTitle: string;
+
+  /** Date of the first available observation in `"DD-MM-YYYY"` format. */
+  firstObservation: string;
+
+  /** Date of the last available observation in `"DD-MM-YYYY"` format. */
+  lastObservation: string;
+
+  /** Date the series was last updated in `"DD-MM-YYYY"` format. */
+  updatedAt: string;
+
+  /** Date the series was created in `"DD-MM-YYYY"` format. */
+  createdAt: string;
+}
+
+/**
+ * Observation frequency accepted by {@link Client.searchSeries}.
+ */
+export type Frequency = 'DAILY' | 'MONTHLY' | 'QUARTERLY' | 'ANNUAL';
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the BCCH API returns a non-zero `Codigo` in the response body.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await client.getSeries('INVALID');
+ * } catch (err) {
+ *   if (err instanceof ApiError) {
+ *     console.error(`API error ${err.codigo}: ${err.descripcion}`);
+ *   }
+ * }
+ * ```
+ */
+export class ApiError extends Error {
+  /** Non-zero `Codigo` value from the API response. */
+  readonly codigo: number;
+
+  /** `Descripcion` string from the API response. */
+  readonly descripcion: string;
+
+  constructor(message: string, codigo: number, descripcion: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.codigo = codigo;
+    this.descripcion = descripcion;
+  }
+}
+
+/**
+ * Thrown when the BCCH API returns a non-ok HTTP status code.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await client.getSeries('F022.TPM.TIN.D001.NO.Z.D');
+ * } catch (err) {
+ *   if (err instanceof HttpError) {
+ *     console.error(`HTTP ${err.status}`);
+ *   }
+ * }
+ * ```
+ */
+export class HttpError extends Error {
+  /** HTTP status code. */
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,28 @@
-/**
- * Returns a personalised greeting for the given name.
- *
- * @param name - The name to greet.
- * @returns A greeting string in the form `"Hello, <name>!"`.
- *
- * @example
- * ```ts
- * hello('World'); // "Hello, World!"
- * ```
- */
-export function hello(name: string): string {
-  return `Hello, ${name}!`;
-}
+export { Client, ApiError, HttpError } from './client/index.js';
+export type {
+  ClientOptions,
+  Frequency,
+  GetSeriesOptions,
+  Observation,
+  SeriesData,
+  SeriesInfo,
+} from './client/index.js';
+
+export { SERIES } from './series/index.js';
+
+export {
+  parseObservationDate,
+  formatQueryDate,
+  filterValid,
+  parseValue,
+  toArrays,
+  toMap,
+  toNumbers,
+  annualVariation,
+  max,
+  mean,
+  min,
+  periodVariation,
+  rollingMean,
+  stdDev,
+} from './utils/index.js';

--- a/src/series/index.ts
+++ b/src/series/index.ts
@@ -1,0 +1,1 @@
+export { SERIES } from './series.js';

--- a/src/series/series.ts
+++ b/src/series/series.ts
@@ -1,0 +1,220 @@
+/**
+ * Curated constants for commonly used BCCH series identifiers.
+ *
+ * This is not an exhaustive catalog — it covers the most frequently queried
+ * series across key macroeconomic domains. Use {@link https://si3.bcentral.cl/siete | si3.bcentral.cl}
+ * or {@link Client.searchSeries} to discover additional series IDs.
+ *
+ * @example
+ * ```ts
+ * import { Client } from 'bcch/client';
+ * import { SERIES } from 'bcch/series';
+ *
+ * const client = new Client({ user: '...', pass: '...' });
+ * const data = await client.getSeries(SERIES.PRICES.UF);
+ * ```
+ */
+export const SERIES = {
+  /**
+   * Exchange rate series.
+   *
+   * USD/CLP is expressed as Chilean Pesos per USD.
+   * All other pairs are expressed as foreign currency units per 1 USD.
+   */
+  EXCHANGE_RATE: {
+    /** Observed (official) USD/CLP exchange rate — daily. */
+    USD_CLP_OBSERVED: 'F073.TCO.PRE.Z.D',
+    /** Argentine Peso per USD — daily. */
+    ARS_USD: 'F072.ARS.USD.N.O.D',
+    /** Australian Dollar per USD — daily. */
+    AUD_USD: 'F072.AUD.USD.N.O.D',
+    /** Brazilian Real per USD — daily. */
+    BRL_USD: 'F072.BRL.USD.N.O.D',
+    /** Canadian Dollar per USD — daily. */
+    CAD_USD: 'F072.CAD.USD.N.O.D',
+    /** Yuan Renminbi per USD — daily. */
+    CNY_USD: 'F072.CNY.USD.N.O.D',
+    /** Colombian Peso per USD — daily. */
+    COP_USD: 'F072.COP.USD.N.O.D',
+    /** Euro per USD — daily. */
+    EUR_USD: 'F072.EUR.USD.N.O.D',
+    /** Pound Sterling per USD — daily. */
+    GBP_USD: 'F072.GBP.USD.N.O.D',
+    /** Hong Kong Dollar per USD — daily. */
+    HKD_USD: 'F072.HKD.USD.N.O.D',
+    /** Japanese Yen per USD — daily. */
+    JPY_USD: 'F072.JPY.USD.N.O.D',
+    /** Mexican Peso per USD — daily. */
+    MXN_USD: 'F072.MXN.USD.N.O.D',
+    /** Norwegian Krone per USD — daily. */
+    NOK_USD: 'F072.NOK.USD.N.O.D',
+    /** Peruvian Sol per USD — daily. */
+    PEN_USD: 'F072.PEN.USD.N.O.D',
+    /** Swedish Krona per USD — daily. */
+    SEK_USD: 'F072.SEK.USD.N.O.D',
+    /** Swiss Franc per USD — daily. */
+    CHF_USD: 'F072.CHF.USD.N.O.D',
+    /** IMF Special Drawing Rights per USD — daily. */
+    SDR_USD: 'F072.DEG.USD.N.O.D',
+  },
+
+  /**
+   * Price index and inflation series.
+   */
+  PRICES: {
+    /** Unidad de Fomento (UF) — daily. */
+    UF: 'F073.UFF.PRE.Z.D',
+    /** Average Value Index (IVP) — daily. */
+    IVP: 'F073.IVP.PRE.Z.D',
+    /** Monthly Tax Unit (UTM) — monthly. */
+    UTM: 'F073.UTR.PRE.Z.M',
+    /** Headline CPI index (base 2023) — monthly. */
+    CPI_INDEX: 'F074.IPC.IND.Z.EP23.C.M',
+    /** Headline CPI monthly change — monthly. */
+    CPI_MONTHLY_CHANGE: 'F074.IPC.VAR.Z.EP23.C.M',
+    /** Headline CPI annual change (12-month) — monthly. */
+    CPI_ANNUAL_CHANGE: 'F074.IPC.V12.Z.EP23.C.M',
+    /** CPI excluding food and energy (SAE) — monthly. */
+    CPI_SAE: 'F074.IPCSAE.VAR.Z.2023.C.M',
+    /** Tradable CPI — monthly. */
+    CPI_TRADABLE: 'F074.IPCT.VAR.Z.2023.C.M',
+    /** Non-tradable CPI — monthly. */
+    CPI_NON_TRADABLE: 'F074.IPCN.VAR.Z.2023.C.M',
+    /** CPI food — monthly. */
+    CPI_FOOD: 'F074.IPCA.VAR.Z.2023.C.M',
+    /** CPI energy — monthly. */
+    CPI_ENERGY: 'F074.IPCE.VAR.Z.2023.C.M',
+    /** CPI services — monthly. */
+    CPI_SERVICES: 'F074.IPCS.VAR.Z.2023.C.M',
+    /** CPI goods — monthly. */
+    CPI_GOODS: 'F074.IPCB.VAR.Z.2023.C.M',
+  },
+
+  /**
+   * Interest rate series (policy rates, sovereign bonds, money market instruments).
+   */
+  INTEREST_RATES: {
+    /** Monetary Policy Rate (MPR/TPM) — daily. */
+    MONETARY_POLICY_RATE: 'F022.TPM.TIN.D001.NO.Z.D',
+    /** Permanent liquidity facility rate — daily. */
+    LIQUIDITY_FACILITY: 'F022.TPL.TIN.Z.NO.Z.D',
+    /** Permanent deposit facility rate — daily. */
+    DEPOSIT_FACILITY: 'F022.TPD.TIN.Z.NO.Z.D',
+    /** 2-year nominal BCP sovereign bond yield — daily. */
+    BCP_2Y: 'F022.BCLP.TIS.AN02.NO.Z.D',
+    /** 5-year nominal BCP sovereign bond yield — daily. */
+    BCP_5Y: 'F022.BCLP.TIS.AN05.NO.Z.D',
+    /** 10-year nominal BCP sovereign bond yield — daily. */
+    BCP_10Y: 'F022.BCLP.TIS.AN10.NO.Z.D',
+    /** 2-year inflation-linked BCU sovereign bond yield — daily. */
+    BCU_2Y: 'F022.BUF.TIS.AN02.UF.Z.D',
+    /** 5-year inflation-linked BCU sovereign bond yield — daily. */
+    BCU_5Y: 'F022.BUF.TIS.AN05.UF.Z.D',
+    /** 10-year inflation-linked BCU sovereign bond yield — daily. */
+    BCU_10Y: 'F022.BUF.TIS.AN10.UF.Z.D',
+    /** 30-day PDBC rate — monthly. */
+    PDBC_30D: 'F022.PDBC.TIN.D030.NO.Z.M',
+    /** 90-day PDBC rate — monthly. */
+    PDBC_90D: 'F022.PDBC.TIN.D090.NO.Z.M',
+    /** 180-day PDBC rate — monthly. */
+    PDBC_180D: 'F022.PDBC.TIN.D180.NO.Z.M',
+  },
+
+  /**
+   * Monetary aggregates and credit series.
+   */
+  MONEY: {
+    /** Narrow money supply M1 — monthly. */
+    M1: 'F021.M1.PRO.N.CLP.5.M',
+    /** Broad money supply M2 — monthly. */
+    M2: 'F021.M2.PRO.N.CLP.5.M',
+    /** Broadest money supply M3 — monthly. */
+    M3: 'F021.M3.PRO.N.CLP.5.M',
+    /** Total real bank loans — monthly. */
+    LOANS_TOTAL: 'F022.CTO.STO.TP.Z.P96R23.M',
+    /** Real consumer loans — monthly. */
+    LOANS_CONSUMER: 'F022.CON.STO.TP.Z.P96R23.M',
+    /** Real mortgage loans — monthly. */
+    LOANS_MORTGAGE: 'F022.VIV.STO.TP.Z.P96R23.M',
+    /** Real commercial loans — monthly. */
+    LOANS_COMMERCIAL: 'F022.CEM.STO.TP.Z.P96R23.M',
+  },
+
+  /**
+   * National accounts and economic activity series.
+   */
+  NATIONAL_ACCOUNTS: {
+    /** Imacec index (economic activity, 2018=100) — monthly. */
+    IMACEC: 'F032.IMC.IND.Z.Z.EP18.Z.Z.0.M',
+    /** Imacec 12-month annual change — monthly. */
+    IMACEC_ANNUAL_CHANGE: 'F032.IMC.V12.Z.Z.2018.Z.Z.0.M',
+    /** Non-mining Imacec index — monthly. */
+    IMACEC_NON_MINING: 'F032.IMC.IND.Z.Z.EP18.N03.Z.0.M',
+    /** Mining Imacec — monthly. */
+    IMACEC_MINING: 'F032.IMC.IND.Z.Z.EP18.03.Z.0.M',
+    /** Manufacturing Imacec — monthly. */
+    IMACEC_MANUFACTURING: 'F032.IMC.IND.Z.Z.EP18.04.Z.0.M',
+    /** Services Imacec — monthly. */
+    IMACEC_SERVICES: 'F032.IMC.IND.Z.Z.EP18.SERV.Z.0.M',
+  },
+
+  /**
+   * External sector and balance of payments series.
+   */
+  EXTERNAL_SECTOR: {
+    /** Current account balance — quarterly. */
+    CURRENT_ACCOUNT: 'F068.A.FLU.Z.0.S.N.Z.Z.Z.Z.6.0.T',
+    /** Trade balance of goods and services — quarterly. */
+    TRADE_BALANCE: 'F068.B.FLU.Z.0.S.N.Z.Z.Z.Z.6.0.T',
+    /** Goods exports — monthly. */
+    EXPORTS: 'F068.B1.FLU.Z.0.C.N.Z.Z.Z.Z.6.0.M',
+    /** Goods imports (FOB) — monthly. */
+    IMPORTS: 'F068.B1.FLU.Z.0.D.N.0.T.Z.Z.6.0.M',
+    /** Financial account — monthly. */
+    FINANCIAL_ACCOUNT: 'F068.G.FLU.Z.0.S.N.Z.T.Z.Z.6.0.M',
+    /** Foreign direct investment (net) — monthly. */
+    DIRECT_INVESTMENT: 'F068.G1.FLU.Z.0.S.N.Z.T.Z.Z.6.0.M',
+    /** International reserve assets — monthly. */
+    RESERVE_ASSETS: 'F068.G5.FLU.W.0.S.N.Z.T.Z.Z.6.0.M',
+  },
+
+  /**
+   * Labour market series.
+   */
+  EMPLOYMENT: {
+    /** Nationwide unemployment rate — monthly. */
+    UNEMPLOYMENT_RATE: 'F049.DES.TAS.INE9.10.M',
+    /** Total labour force (persons) — monthly. */
+    LABOUR_FORCE: 'F049.FTR.PMT.INE9.01.M',
+    /** Employed persons — monthly. */
+    EMPLOYED: 'F049.OCU.PMT.INE9.01.M',
+    /** Unemployed persons — monthly. */
+    UNEMPLOYED: 'F049.DES.PMT.INE9.01.M',
+  },
+
+  /**
+   * Central government fiscal series.
+   */
+  PUBLIC_FINANCES: {
+    /** Total government revenue — annual. */
+    REVENUE: 'F051.A01.FLU.G.C.CLP.T',
+    /** Total government expenditure — annual. */
+    EXPENDITURE: 'F051.A02.FLU.G.C.CLP.T',
+    /** Net tax revenues — annual. */
+    TAX_REVENUE: 'F051.A011.FLU.G.C.CLP.T',
+    /** Net lending / net borrowing (fiscal balance) — annual. */
+    FISCAL_BALANCE: 'F051.B04.FLU.G.C.CLP.T',
+    /** Net foreign exchange reserves (central government) — annual. */
+    FX_RESERVES: 'F051.E21.STO.H.Z.USD.T',
+  },
+
+  /**
+   * Capital market series.
+   */
+  CAPITAL_MARKET: {
+    /** IPSA equity index (base January 2003=100) — daily. */
+    IPSA: 'F013.IBC.IND.N.7.LAC.CL.CLP.BLO.D',
+    /** Total stock market capitalisation — monthly. */
+    STOCK_MARKET_CAPITAL: 'F022.BCP.STO.Z.Z.CLP.D',
+  },
+} as const;

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,76 @@
+/**
+ * Parses a date string in `"DD-MM-YYYY"` format (the BCCH API wire format)
+ * into a UTC `Date`.
+ *
+ * @param dateString - Date in `"DD-MM-YYYY"` format.
+ * @returns A `Date` set to midnight UTC on the given date.
+ * @throws {Error} When `dateString` is empty, malformed, or out of range.
+ *
+ * @example
+ * ```ts
+ * const d = parseObservationDate('15-06-2023');
+ * d.getUTCFullYear(); // 2023
+ * d.getUTCMonth();    // 5 (June, 0-indexed)
+ * d.getUTCDate();     // 15
+ * ```
+ */
+export function parseObservationDate(dateString: string): Date {
+  if (!dateString) {
+    throw new Error(`Invalid date: "${dateString}"`);
+  }
+
+  const parts = dateString.split('-');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid date: "${dateString}"`);
+  }
+
+  const [dayStr, monthStr, yearStr] = parts;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  const year = Number(yearStr);
+
+  if (
+    !Number.isInteger(day) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(year) ||
+    isNaN(day) ||
+    isNaN(month) ||
+    isNaN(year) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    throw new Error(`Invalid date: "${dateString}"`);
+  }
+
+  // Verify the date is real by constructing and checking for roll-over
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid date: "${dateString}"`);
+  }
+
+  return date;
+}
+
+/**
+ * Formats a `Date` as a `"YYYY-MM-DD"` string for use in BCCH API query parameters.
+ *
+ * @param date - The date to format. Time components are ignored; UTC date is used.
+ * @returns Date string in `"YYYY-MM-DD"` format.
+ *
+ * @example
+ * ```ts
+ * formatQueryDate(new Date(Date.UTC(2024, 0, 15))); // "2024-01-15"
+ * ```
+ */
+export function formatQueryDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { formatQueryDate, parseObservationDate } from './dates.js';
+export { filterValid, parseValue, toArrays, toMap, toNumbers } from './transform.js';
+export { annualVariation, max, mean, min, periodVariation, rollingMean, stdDev } from './stats.js';

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,192 @@
+import { parseValue } from './transform.js';
+import type { Observation } from '../client/types.js';
+
+function validNumbers(observations: Observation[]): number[] {
+  const result: number[] = [];
+  for (const obs of observations) {
+    const n = parseValue(obs.value);
+    if (n !== null) {
+      result.push(n);
+    }
+  }
+  return result;
+}
+
+/**
+ * Calculates the arithmetic mean of valid observation values, ignoring gaps.
+ *
+ * @param observations - Array of observations.
+ * @returns The arithmetic mean.
+ * @throws {Error} When there are no valid (non-null) values.
+ *
+ * @example
+ * ```ts
+ * mean(data.observations); // 1.78
+ * ```
+ */
+export function mean(observations: Observation[]): number {
+  const values = validNumbers(observations);
+  if (values.length === 0) {
+    throw new Error('No valid observations to compute mean');
+  }
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/**
+ * Calculates the sample standard deviation of valid observation values,
+ * ignoring gaps.
+ *
+ * Uses Bessel's correction (divides by `n - 1`).
+ *
+ * @param observations - Array of observations.
+ * @returns The sample standard deviation.
+ * @throws {Error} When fewer than two valid values are present.
+ *
+ * @example
+ * ```ts
+ * stdDev(data.observations); // 0.035
+ * ```
+ */
+export function stdDev(observations: Observation[]): number {
+  const values = validNumbers(observations);
+  if (values.length < 2) {
+    throw new Error('stdDev requires at least two valid observations');
+  }
+  const avg = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + (v - avg) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+/**
+ * Returns the minimum valid observation value, ignoring gaps.
+ *
+ * @param observations - Array of observations.
+ * @returns The minimum value.
+ * @throws {Error} When there are no valid values.
+ *
+ * @example
+ * ```ts
+ * min(data.observations); // 0.5
+ * ```
+ */
+export function min(observations: Observation[]): number {
+  const values = validNumbers(observations);
+  if (values.length === 0) {
+    throw new Error('No valid observations to compute min');
+  }
+  return Math.min(...values);
+}
+
+/**
+ * Returns the maximum valid observation value, ignoring gaps.
+ *
+ * @param observations - Array of observations.
+ * @returns The maximum value.
+ * @throws {Error} When there are no valid values.
+ *
+ * @example
+ * ```ts
+ * max(data.observations); // 8.25
+ * ```
+ */
+export function max(observations: Observation[]): number {
+  const values = validNumbers(observations);
+  if (values.length === 0) {
+    throw new Error('No valid observations to compute max');
+  }
+  return Math.max(...values);
+}
+
+/**
+ * Calculates period-over-period fractional change for each observation.
+ *
+ * The result at index `i` is `value[i] / value[i-1] - 1`.
+ * Returns `null` for the first position, and for any position where the
+ * current or previous value is `null`.
+ *
+ * @param observations - Array of observations in chronological order.
+ * @returns Array of fractional changes, same length as input, `null` for gaps.
+ *
+ * @example
+ * ```ts
+ * // values: 100, 105, null, 110
+ * periodVariation(obs); // [null, 0.05, null, null]
+ * ```
+ */
+export function periodVariation(observations: Observation[]): Array<number | null> {
+  const values = observations.map((obs) => parseValue(obs.value));
+  return values.map((current, i) => {
+    if (i === 0) return null;
+    const previous = values[i - 1] ?? null;
+    if (current === null || previous === null || previous === 0) return null;
+    return current / previous - 1;
+  });
+}
+
+/**
+ * Calculates year-over-year fractional change using a fixed period offset.
+ *
+ * The result at index `i` is `value[i] / value[i - periodsPerYear] - 1`.
+ * Returns `null` for the first `periodsPerYear` positions, and for any
+ * position where the current or base value is `null`.
+ *
+ * @param observations - Array of observations in chronological order.
+ * @param periodsPerYear - Number of periods per year (e.g. `12` for monthly,
+ *   `4` for quarterly, `252` for daily trading days).
+ * @returns Array of fractional changes, same length as input.
+ * @throws {Error} When `periodsPerYear` is not a positive integer.
+ *
+ * @example
+ * ```ts
+ * // Monthly CPI, 12-month change
+ * annualVariation(cpi.observations, 12);
+ * ```
+ */
+export function annualVariation(
+  observations: Observation[],
+  periodsPerYear: number,
+): Array<number | null> {
+  if (!Number.isInteger(periodsPerYear) || periodsPerYear < 1) {
+    throw new Error(`periodsPerYear must be a positive integer, got: ${periodsPerYear}`);
+  }
+
+  const values = observations.map((obs) => parseValue(obs.value));
+  return values.map((current, i) => {
+    if (i < periodsPerYear) return null;
+    const base = values[i - periodsPerYear] ?? null;
+    if (current === null || base === null || base === 0) return null;
+    return current / base - 1;
+  });
+}
+
+/**
+ * Calculates a rolling (moving) average over a fixed window of observations.
+ *
+ * Returns `null` for positions before the window is full, and for any window
+ * that contains at least one gap value.
+ *
+ * @param observations - Array of observations in chronological order.
+ * @param window - Number of periods in the rolling window.
+ * @returns Array of rolling means, same length as input.
+ * @throws {Error} When `window` is not a positive integer.
+ *
+ * @example
+ * ```ts
+ * // 3-month moving average
+ * rollingMean(data.observations, 3);
+ * ```
+ */
+export function rollingMean(observations: Observation[], window: number): Array<number | null> {
+  if (!Number.isInteger(window) || window < 1) {
+    throw new Error(`window must be a positive integer, got: ${window}`);
+  }
+
+  const values = observations.map((obs) => parseValue(obs.value));
+  return values.map((_, i) => {
+    if (i < window - 1) return null;
+    const slice = values.slice(i - window + 1, i + 1);
+    if (slice.some((v) => v === null)) return null;
+    const sum = (slice as number[]).reduce((acc, v) => acc + v, 0);
+    return sum / window;
+  });
+}

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,0 +1,109 @@
+import { parseObservationDate } from './dates.js';
+import type { Observation } from '../client/types.js';
+
+/**
+ * Parses a raw observation value string to a number, or `null` for gaps.
+ *
+ * @param value - Raw value string from an {@link Observation}.
+ * @returns The parsed number, or `null` when the string is empty or non-numeric.
+ *
+ * @example
+ * ```ts
+ * parseValue('1.75');  // 1.75
+ * parseValue('');      // null
+ * parseValue('N/A');   // null
+ * ```
+ */
+export function parseValue(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const n = Number(trimmed);
+  return isNaN(n) ? null : n;
+}
+
+/**
+ * Filters an array of observations, returning only those with parseable values.
+ *
+ * An observation is considered valid when its `value` field is a non-empty,
+ * numeric string (i.e. `parseValue` returns a number, not `null`).
+ *
+ * @param observations - Array of observations to filter.
+ * @returns A new array containing only the valid observations.
+ *
+ * @example
+ * ```ts
+ * const valid = filterValid(data.observations);
+ * ```
+ */
+export function filterValid(observations: Observation[]): Observation[] {
+  return observations.filter((obs) => parseValue(obs.value) !== null);
+}
+
+/**
+ * Converts an array of observations to an array of `number | null` values.
+ *
+ * Gaps (empty or non-numeric values) are represented as `null`, preserving
+ * the positional alignment with the original observations array.
+ *
+ * @param observations - Array of observations to convert.
+ * @returns Array of parsed values, `null` for gaps.
+ *
+ * @example
+ * ```ts
+ * toNumbers(data.observations); // [1.75, null, 1.80, ...]
+ * ```
+ */
+export function toNumbers(observations: Observation[]): Array<number | null> {
+  return observations.map((obs) => parseValue(obs.value));
+}
+
+/**
+ * Converts an array of observations to a `Map` keyed by the observation date
+ * string (`"DD-MM-YYYY"`).
+ *
+ * When duplicate dates exist, the last one wins. Values are `null` for gaps.
+ *
+ * @param observations - Array of observations to convert.
+ * @returns Map from date string to `number | null`.
+ *
+ * @example
+ * ```ts
+ * const map = toMap(data.observations);
+ * map.get('01-01-2024'); // 1.75
+ * ```
+ */
+export function toMap(observations: Observation[]): Map<string, number | null> {
+  const result = new Map<string, number | null>();
+  for (const obs of observations) {
+    result.set(obs.indexDateString, parseValue(obs.value));
+  }
+  return result;
+}
+
+/**
+ * Converts an array of observations to parallel `dates` and `values` arrays
+ * suitable for charting libraries.
+ *
+ * @param observations - Array of observations to convert.
+ * @returns Object with `dates` (UTC `Date[]`) and `values` (`Array<number | null>`).
+ *
+ * @example
+ * ```ts
+ * const { dates, values } = toArrays(data.observations);
+ * // pass to Chart.js, D3, etc.
+ * ```
+ */
+export function toArrays(observations: Observation[]): {
+  dates: Date[];
+  values: Array<number | null>;
+} {
+  const dates: Date[] = [];
+  const values: Array<number | null> = [];
+  for (const obs of observations) {
+    dates.push(parseObservationDate(obs.indexDateString));
+    values.push(parseValue(obs.value));
+  }
+  return { dates, values };
+}

--- a/tests/client/client.test.ts
+++ b/tests/client/client.test.ts
@@ -1,0 +1,373 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ApiError, Client, HttpError } from '../../src/client/index.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_URL = 'https://si3.bcentral.cl/SieteRestWS/SieteRestWS.ashx';
+
+function makeFetch(body: unknown, status = 200): typeof globalThis.fetch {
+  return async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+function makeCredentials() {
+  return { user: 'user@example.com', pass: 's3cr3t' };
+}
+
+const SERIES_ID = 'F022.TPM.TIN.D001.NO.Z.D';
+
+const MOCK_GET_SERIES_RESPONSE = {
+  Codigo: 0,
+  Descripcion: 'Success',
+  Series: {
+    descripEsp: 'Tasa de Política Monetaria (porcentaje)',
+    descripIng: 'Monetary policy rate (MPR) (percentage)',
+    seriesId: SERIES_ID,
+    Obs: [
+      { indexDateString: '01-01-2020', value: '1.75', statusCode: 'OK' },
+      { indexDateString: '02-01-2020', value: '', statusCode: 'NO_OBS' },
+    ],
+  },
+  SeriesInfos: null,
+};
+
+const MOCK_SEARCH_SERIES_RESPONSE = {
+  Codigo: 0,
+  Descripcion: 'Success',
+  Series: null,
+  SeriesInfos: [
+    {
+      seriesId: SERIES_ID,
+      frequencyCode: 'DAILY',
+      spanishTitle: 'Tasa de Política Monetaria',
+      englishTitle: 'Monetary policy rate',
+      firstObservation: '01-01-2002',
+      lastObservation: '10-03-2026',
+      updatedAt: '10-03-2026',
+      createdAt: '01-01-2002',
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// ApiError
+// ---------------------------------------------------------------------------
+
+describe('ApiError', () => {
+  it('is an instance of Error', () => {
+    const err = new ApiError('failed', 101, 'Series not found');
+    assert.ok(err instanceof Error);
+  });
+
+  it('is an instance of ApiError', () => {
+    const err = new ApiError('failed', 101, 'Series not found');
+    assert.ok(err instanceof ApiError);
+  });
+
+  it('exposes codigo and descripcion', () => {
+    const err = new ApiError('failed', 42, 'Bad input');
+    assert.equal(err.codigo, 42);
+    assert.equal(err.descripcion, 'Bad input');
+  });
+
+  it('has the correct message', () => {
+    const err = new ApiError('API call failed', 101, 'Series not found');
+    assert.equal(err.message, 'API call failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HttpError
+// ---------------------------------------------------------------------------
+
+describe('HttpError', () => {
+  it('is an instance of Error', () => {
+    const err = new HttpError('HTTP error', 404);
+    assert.ok(err instanceof Error);
+  });
+
+  it('is an instance of HttpError', () => {
+    const err = new HttpError('HTTP error', 404);
+    assert.ok(err instanceof HttpError);
+  });
+
+  it('exposes status', () => {
+    const err = new HttpError('Not Found', 404);
+    assert.equal(err.status, 404);
+  });
+
+  it('has the correct message', () => {
+    const err = new HttpError('Not Found', 404);
+    assert.equal(err.message, 'Not Found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client — getSeries
+// ---------------------------------------------------------------------------
+
+describe('Client.getSeries', () => {
+  it('returns parsed SeriesData on success', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_GET_SERIES_RESPONSE),
+    });
+
+    const data = await client.getSeries(SERIES_ID);
+
+    assert.equal(data.seriesId, SERIES_ID);
+    assert.equal(data.descripEsp, 'Tasa de Política Monetaria (porcentaje)');
+    assert.equal(data.descripIng, 'Monetary policy rate (MPR) (percentage)');
+    assert.equal(data.observations.length, 2);
+  });
+
+  it('maps observations correctly', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_GET_SERIES_RESPONSE),
+    });
+
+    const data = await client.getSeries(SERIES_ID);
+
+    assert.deepEqual(data.observations[0], {
+      indexDateString: '01-01-2020',
+      value: '1.75',
+      statusCode: 'OK',
+    });
+    assert.deepEqual(data.observations[1], {
+      indexDateString: '02-01-2020',
+      value: '',
+      statusCode: 'NO_OBS',
+    });
+  });
+
+  it('includes user, pass, function, and timeseries in the request URL', async () => {
+    let capturedUrl = '';
+    const captureFetch: typeof globalThis.fetch = async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(MOCK_GET_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: captureFetch });
+    await client.getSeries(SERIES_ID);
+
+    const url = new URL(capturedUrl);
+    assert.equal(url.origin + url.pathname, BASE_URL);
+    assert.equal(url.searchParams.get('user'), 'user@example.com');
+    assert.equal(url.searchParams.get('pass'), 's3cr3t');
+    assert.equal(url.searchParams.get('function'), 'GetSeries');
+    assert.equal(url.searchParams.get('timeseries'), SERIES_ID);
+  });
+
+  it('includes firstdate in the request URL when provided', async () => {
+    let capturedUrl = '';
+    const captureFetch: typeof globalThis.fetch = async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(MOCK_GET_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: captureFetch });
+    await client.getSeries(SERIES_ID, { firstdate: '2020-01-01' });
+
+    const url = new URL(capturedUrl);
+    assert.equal(url.searchParams.get('firstdate'), '2020-01-01');
+    assert.equal(url.searchParams.has('lastdate'), false);
+  });
+
+  it('includes lastdate in the request URL when provided', async () => {
+    let capturedUrl = '';
+    const captureFetch: typeof globalThis.fetch = async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(MOCK_GET_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: captureFetch });
+    await client.getSeries(SERIES_ID, { lastdate: '2020-12-31' });
+
+    const url = new URL(capturedUrl);
+    assert.equal(url.searchParams.has('firstdate'), false);
+    assert.equal(url.searchParams.get('lastdate'), '2020-12-31');
+  });
+
+  it('includes both firstdate and lastdate when both are provided', async () => {
+    let capturedUrl = '';
+    const captureFetch: typeof globalThis.fetch = async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(MOCK_GET_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: captureFetch });
+    await client.getSeries(SERIES_ID, {
+      firstdate: '2020-01-01',
+      lastdate: '2020-12-31',
+    });
+
+    const url = new URL(capturedUrl);
+    assert.equal(url.searchParams.get('firstdate'), '2020-01-01');
+    assert.equal(url.searchParams.get('lastdate'), '2020-12-31');
+  });
+
+  it('throws ApiError when Codigo is non-zero', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch({
+        Codigo: 101,
+        Descripcion: 'Series not found',
+        Series: null,
+        SeriesInfos: null,
+      }),
+    });
+
+    await assert.rejects(
+      () => client.getSeries(SERIES_ID),
+      (err: unknown) => {
+        assert.ok(err instanceof ApiError);
+        assert.equal(err.codigo, 101);
+        assert.equal(err.descripcion, 'Series not found');
+        return true;
+      },
+    );
+  });
+
+  it('throws HttpError on a non-ok HTTP response', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch('Not Found', 404),
+    });
+
+    await assert.rejects(
+      () => client.getSeries(SERIES_ID),
+      (err: unknown) => {
+        assert.ok(err instanceof HttpError);
+        assert.equal(err.status, 404);
+        return true;
+      },
+    );
+  });
+
+  it('throws Error with cause on network failure', async () => {
+    const networkError = new Error('Network failure');
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: async () => {
+        throw networkError;
+      },
+    });
+
+    await assert.rejects(
+      () => client.getSeries(SERIES_ID),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal((err as NodeJS.ErrnoException).cause, networkError);
+        return true;
+      },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client — searchSeries
+// ---------------------------------------------------------------------------
+
+describe('Client.searchSeries', () => {
+  it('returns an array of SeriesInfo on success', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_SEARCH_SERIES_RESPONSE),
+    });
+
+    const infos = await client.searchSeries('DAILY');
+
+    assert.equal(infos.length, 1);
+    assert.deepEqual(infos[0], {
+      seriesId: SERIES_ID,
+      frequencyCode: 'DAILY',
+      spanishTitle: 'Tasa de Política Monetaria',
+      englishTitle: 'Monetary policy rate',
+      firstObservation: '01-01-2002',
+      lastObservation: '10-03-2026',
+      updatedAt: '10-03-2026',
+      createdAt: '01-01-2002',
+    });
+  });
+
+  it('includes user, pass, function, and frequency in the request URL', async () => {
+    let capturedUrl = '';
+    const captureFetch: typeof globalThis.fetch = async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(MOCK_SEARCH_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: captureFetch });
+    await client.searchSeries('MONTHLY');
+
+    const url = new URL(capturedUrl);
+    assert.equal(url.origin + url.pathname, BASE_URL);
+    assert.equal(url.searchParams.get('function'), 'SearchSeries');
+    assert.equal(url.searchParams.get('frequency'), 'MONTHLY');
+    assert.equal(url.searchParams.get('user'), 'user@example.com');
+    assert.equal(url.searchParams.get('pass'), 's3cr3t');
+  });
+
+  it('throws ApiError when Codigo is non-zero', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch({
+        Codigo: 99,
+        Descripcion: 'Invalid frequency',
+        Series: null,
+        SeriesInfos: null,
+      }),
+    });
+
+    await assert.rejects(
+      () => client.searchSeries('DAILY'),
+      (err: unknown) => {
+        assert.ok(err instanceof ApiError);
+        assert.equal(err.codigo, 99);
+        return true;
+      },
+    );
+  });
+
+  it('throws HttpError on a non-ok HTTP response', async () => {
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch('Internal Server Error', 500),
+    });
+
+    await assert.rejects(
+      () => client.searchSeries('DAILY'),
+      (err: unknown) => {
+        assert.ok(err instanceof HttpError);
+        assert.equal(err.status, 500);
+        return true;
+      },
+    );
+  });
+
+  it('throws Error with cause on network failure', async () => {
+    const networkError = new Error('DNS failure');
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: async () => {
+        throw networkError;
+      },
+    });
+
+    await assert.rejects(
+      () => client.searchSeries('QUARTERLY'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal((err as NodeJS.ErrnoException).cause, networkError);
+        return true;
+      },
+    );
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,17 +1,37 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { hello } from '../src/index.ts';
+import { Client, ApiError, HttpError, SERIES, mean, parseObservationDate } from '../src/index.ts';
 
-describe('hello', () => {
-  it('returns a greeting containing the given name', () => {
-    assert.equal(hello('World'), 'Hello, World!');
+describe('bcch root exports', () => {
+  it('exports Client', () => {
+    assert.equal(typeof Client, 'function');
   });
 
-  it('returns a greeting with the exact format "Hello, <name>!"', () => {
-    assert.equal(hello('Node'), 'Hello, Node!');
+  it('exports ApiError', () => {
+    const err = new ApiError('msg', 1, 'desc');
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof ApiError);
   });
 
-  it('returns a greeting when name is an empty string', () => {
-    assert.equal(hello(''), 'Hello, !');
+  it('exports HttpError', () => {
+    const err = new HttpError('msg', 500);
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof HttpError);
+  });
+
+  it('exports SERIES with expected groups', () => {
+    assert.equal(typeof SERIES, 'object');
+    assert.ok('EXCHANGE_RATE' in SERIES);
+    assert.ok('PRICES' in SERIES);
+    assert.ok('INTEREST_RATES' in SERIES);
+  });
+
+  it('exports mean from utils', () => {
+    assert.equal(typeof mean, 'function');
+  });
+
+  it('exports parseObservationDate from utils', () => {
+    const d = parseObservationDate('01-01-2024');
+    assert.equal(d.getUTCFullYear(), 2024);
   });
 });

--- a/tests/series/series.test.ts
+++ b/tests/series/series.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { SERIES } from '../../src/series/index.ts';
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+describe('SERIES', () => {
+  it('is a plain object (not a class instance)', () => {
+    assert.equal(Object.getPrototypeOf(SERIES), Object.prototype);
+  });
+
+  it('has all expected top-level groups', () => {
+    const expected = [
+      'EXCHANGE_RATE',
+      'PRICES',
+      'INTEREST_RATES',
+      'MONEY',
+      'NATIONAL_ACCOUNTS',
+      'EXTERNAL_SECTOR',
+      'EMPLOYMENT',
+      'PUBLIC_FINANCES',
+      'CAPITAL_MARKET',
+    ];
+    for (const key of expected) {
+      assert.ok(key in SERIES, `Missing group: ${key}`);
+    }
+  });
+
+  it('every group is a plain object', () => {
+    for (const [group, members] of Object.entries(SERIES)) {
+      assert.equal(
+        Object.getPrototypeOf(members),
+        Object.prototype,
+        `Group ${group} is not a plain object`,
+      );
+    }
+  });
+
+  it('every series ID is a non-empty string', () => {
+    for (const [group, members] of Object.entries(SERIES)) {
+      for (const [key, value] of Object.entries(members as Record<string, unknown>)) {
+        assert.equal(typeof value, 'string', `${group}.${key} is not a string`);
+        assert.ok((value as string).length > 0, `${group}.${key} is empty`);
+      }
+    }
+  });
+
+  it('no duplicate series IDs within a group', () => {
+    for (const [group, members] of Object.entries(SERIES)) {
+      const values = Object.values(members as Record<string, string>);
+      const unique = new Set(values);
+      assert.equal(unique.size, values.length, `Duplicate IDs in group: ${group}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXCHANGE_RATE — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.EXCHANGE_RATE', () => {
+  it('contains USD_CLP_OBSERVED', () => {
+    assert.equal(SERIES.EXCHANGE_RATE.USD_CLP_OBSERVED, 'F073.TCO.PRE.Z.D');
+  });
+
+  it('contains EUR_USD', () => {
+    assert.equal(SERIES.EXCHANGE_RATE.EUR_USD, 'F072.EUR.USD.N.O.D');
+  });
+
+  it('contains CNY_USD', () => {
+    assert.equal(SERIES.EXCHANGE_RATE.CNY_USD, 'F072.CNY.USD.N.O.D');
+  });
+
+  it('contains BRL_USD', () => {
+    assert.equal(SERIES.EXCHANGE_RATE.BRL_USD, 'F072.BRL.USD.N.O.D');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRICES — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.PRICES', () => {
+  it('contains UF', () => {
+    assert.equal(SERIES.PRICES.UF, 'F073.UFF.PRE.Z.D');
+  });
+
+  it('contains UTM', () => {
+    assert.equal(SERIES.PRICES.UTM, 'F073.UTR.PRE.Z.M');
+  });
+
+  it('contains CPI_MONTHLY_CHANGE', () => {
+    assert.equal(SERIES.PRICES.CPI_MONTHLY_CHANGE, 'F074.IPC.VAR.Z.EP23.C.M');
+  });
+
+  it('contains CPI_ANNUAL_CHANGE', () => {
+    assert.equal(SERIES.PRICES.CPI_ANNUAL_CHANGE, 'F074.IPC.V12.Z.EP23.C.M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INTEREST_RATES — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.INTEREST_RATES', () => {
+  it('contains MONETARY_POLICY_RATE', () => {
+    assert.equal(SERIES.INTEREST_RATES.MONETARY_POLICY_RATE, 'F022.TPM.TIN.D001.NO.Z.D');
+  });
+
+  it('contains BCP_2Y', () => {
+    assert.equal(SERIES.INTEREST_RATES.BCP_2Y, 'F022.BCLP.TIS.AN02.NO.Z.D');
+  });
+
+  it('contains BCP_10Y', () => {
+    assert.equal(SERIES.INTEREST_RATES.BCP_10Y, 'F022.BCLP.TIS.AN10.NO.Z.D');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MONEY — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.MONEY', () => {
+  it('contains M1', () => {
+    assert.equal(SERIES.MONEY.M1, 'F021.M1.PRO.N.CLP.5.M');
+  });
+
+  it('contains M2', () => {
+    assert.equal(SERIES.MONEY.M2, 'F021.M2.PRO.N.CLP.5.M');
+  });
+
+  it('contains M3', () => {
+    assert.equal(SERIES.MONEY.M3, 'F021.M3.PRO.N.CLP.5.M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NATIONAL_ACCOUNTS — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.NATIONAL_ACCOUNTS', () => {
+  it('contains IMACEC', () => {
+    assert.equal(SERIES.NATIONAL_ACCOUNTS.IMACEC, 'F032.IMC.IND.Z.Z.EP18.Z.Z.0.M');
+  });
+
+  it('contains IMACEC_ANNUAL_CHANGE', () => {
+    assert.equal(SERIES.NATIONAL_ACCOUNTS.IMACEC_ANNUAL_CHANGE, 'F032.IMC.V12.Z.Z.2018.Z.Z.0.M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXTERNAL_SECTOR — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.EXTERNAL_SECTOR', () => {
+  it('contains CURRENT_ACCOUNT', () => {
+    assert.equal(SERIES.EXTERNAL_SECTOR.CURRENT_ACCOUNT, 'F068.A.FLU.Z.0.S.N.Z.Z.Z.Z.6.0.T');
+  });
+
+  it('contains EXPORTS', () => {
+    assert.equal(SERIES.EXTERNAL_SECTOR.EXPORTS, 'F068.B1.FLU.Z.0.C.N.Z.Z.Z.Z.6.0.M');
+  });
+
+  it('contains IMPORTS', () => {
+    assert.equal(SERIES.EXTERNAL_SECTOR.IMPORTS, 'F068.B1.FLU.Z.0.D.N.0.T.Z.Z.6.0.M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EMPLOYMENT — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.EMPLOYMENT', () => {
+  it('contains UNEMPLOYMENT_RATE', () => {
+    assert.equal(SERIES.EMPLOYMENT.UNEMPLOYMENT_RATE, 'F049.DES.TAS.INE9.10.M');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUBLIC_FINANCES — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.PUBLIC_FINANCES', () => {
+  it('contains REVENUE', () => {
+    assert.equal(SERIES.PUBLIC_FINANCES.REVENUE, 'F051.A01.FLU.G.C.CLP.T');
+  });
+
+  it('contains EXPENDITURE', () => {
+    assert.equal(SERIES.PUBLIC_FINANCES.EXPENDITURE, 'F051.A02.FLU.G.C.CLP.T');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CAPITAL_MARKET — spot-checks
+// ---------------------------------------------------------------------------
+
+describe('SERIES.CAPITAL_MARKET', () => {
+  it('contains IPSA', () => {
+    assert.equal(SERIES.CAPITAL_MARKET.IPSA, 'F013.IBC.IND.N.7.LAC.CL.CLP.BLO.D');
+  });
+});

--- a/tests/utils/dates.test.ts
+++ b/tests/utils/dates.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { formatQueryDate, parseObservationDate } from '../../src/utils/index.ts';
+
+describe('parseObservationDate', () => {
+  it('parses a valid DD-MM-YYYY string into a Date', () => {
+    const date = parseObservationDate('15-06-2023');
+    assert.equal(date.getUTCFullYear(), 2023);
+    assert.equal(date.getUTCMonth(), 5); // 0-indexed
+    assert.equal(date.getUTCDate(), 15);
+  });
+
+  it('parses 01-01-2000 correctly', () => {
+    const date = parseObservationDate('01-01-2000');
+    assert.equal(date.getUTCFullYear(), 2000);
+    assert.equal(date.getUTCMonth(), 0);
+    assert.equal(date.getUTCDate(), 1);
+  });
+
+  it('parses 31-12-1999 correctly', () => {
+    const date = parseObservationDate('31-12-1999');
+    assert.equal(date.getUTCFullYear(), 1999);
+    assert.equal(date.getUTCMonth(), 11);
+    assert.equal(date.getUTCDate(), 31);
+  });
+
+  it('returns a Date in UTC (no timezone shift)', () => {
+    const date = parseObservationDate('01-03-2024');
+    assert.equal(date.getUTCFullYear(), 2024);
+    assert.equal(date.getUTCMonth(), 2);
+    assert.equal(date.getUTCDate(), 1);
+  });
+
+  it('throws on an empty string', () => {
+    assert.throws(() => parseObservationDate(''), /invalid date/i);
+  });
+
+  it('throws on a wrong-format string (YYYY-MM-DD)', () => {
+    assert.throws(() => parseObservationDate('2023-06-15'), /invalid date/i);
+  });
+
+  it('throws when the date parts are out of range', () => {
+    assert.throws(() => parseObservationDate('99-99-2023'), /invalid date/i);
+  });
+});
+
+describe('formatQueryDate', () => {
+  it('formats a Date to YYYY-MM-DD', () => {
+    const date = new Date(Date.UTC(2024, 0, 15)); // 15 Jan 2024
+    assert.equal(formatQueryDate(date), '2024-01-15');
+  });
+
+  it('zero-pads month and day', () => {
+    const date = new Date(Date.UTC(2023, 2, 5)); // 5 Mar 2023
+    assert.equal(formatQueryDate(date), '2023-03-05');
+  });
+
+  it('round-trips with parseObservationDate', () => {
+    const original = '20-11-2022';
+    const date = parseObservationDate(original);
+    assert.equal(formatQueryDate(date), '2022-11-20');
+  });
+});

--- a/tests/utils/stats.test.ts
+++ b/tests/utils/stats.test.ts
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  annualVariation,
+  max,
+  mean,
+  min,
+  periodVariation,
+  rollingMean,
+  stdDev,
+} from '../../src/utils/index.ts';
+import type { Observation } from '../../src/client/index.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function obs(indexDateString: string, value: string, statusCode = 'OK'): Observation {
+  return { indexDateString, value, statusCode };
+}
+
+// Simple sequence: 1, 2, 3, 4, 5
+const SIMPLE: Observation[] = [
+  obs('01-01-2024', '1'),
+  obs('02-01-2024', '2'),
+  obs('03-01-2024', '3'),
+  obs('04-01-2024', '4'),
+  obs('05-01-2024', '5'),
+];
+
+// Sequence with gaps
+const WITH_GAPS: Observation[] = [
+  obs('01-01-2024', '2'),
+  obs('02-01-2024', '', 'NO_OBS'),
+  obs('03-01-2024', '4'),
+  obs('04-01-2024', '', 'NO_OBS'),
+  obs('05-01-2024', '6'),
+];
+
+// ---------------------------------------------------------------------------
+// mean
+// ---------------------------------------------------------------------------
+
+describe('mean', () => {
+  it('calculates the arithmetic mean of valid observations', () => {
+    assert.equal(mean(SIMPLE), 3);
+  });
+
+  it('ignores null (gap) values', () => {
+    // valid values: 2, 4, 6 → mean = 4
+    assert.equal(mean(WITH_GAPS), 4);
+  });
+
+  it('throws when there are no valid values', () => {
+    assert.throws(() => mean([obs('01-01-2024', '')]), /no valid/i);
+  });
+
+  it('throws on empty input', () => {
+    assert.throws(() => mean([]), /no valid/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stdDev
+// ---------------------------------------------------------------------------
+
+describe('stdDev', () => {
+  it('calculates sample standard deviation', () => {
+    // values: 2, 4 → mean 3, sample variance = ((2-3)²+(4-3)²)/(2-1) = 2, stddev = √2
+    const result = stdDev([obs('01-01-2024', '2'), obs('02-01-2024', '4')]);
+    assert.ok(Math.abs(result - Math.sqrt(2)) < 1e-10);
+  });
+
+  it('ignores gap values', () => {
+    // same as above but with a gap in between
+    const result = stdDev([
+      obs('01-01-2024', '2'),
+      obs('02-01-2024', '', 'NO_OBS'),
+      obs('03-01-2024', '4'),
+    ]);
+    assert.ok(Math.abs(result - Math.sqrt(2)) < 1e-10);
+  });
+
+  it('throws when fewer than two valid values', () => {
+    assert.throws(() => stdDev([obs('01-01-2024', '5')]), /at least two/i);
+  });
+
+  it('throws on empty input', () => {
+    assert.throws(() => stdDev([]), /at least two/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// min / max
+// ---------------------------------------------------------------------------
+
+describe('min', () => {
+  it('returns the minimum valid value', () => {
+    assert.equal(min(SIMPLE), 1);
+  });
+
+  it('ignores gaps', () => {
+    assert.equal(min(WITH_GAPS), 2);
+  });
+
+  it('throws when no valid values', () => {
+    assert.throws(() => min([obs('01-01-2024', '')]), /no valid/i);
+  });
+});
+
+describe('max', () => {
+  it('returns the maximum valid value', () => {
+    assert.equal(max(SIMPLE), 5);
+  });
+
+  it('ignores gaps', () => {
+    assert.equal(max(WITH_GAPS), 6);
+  });
+
+  it('throws when no valid values', () => {
+    assert.throws(() => max([obs('01-01-2024', '')]), /no valid/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// periodVariation
+// ---------------------------------------------------------------------------
+
+describe('periodVariation', () => {
+  it('calculates period-over-period fractional change', () => {
+    // 1→2: +1.0 (100%), 2→3: +0.5 (50%), 3→4: +0.333..., 4→5: +0.25
+    const result = periodVariation(SIMPLE);
+    assert.equal(result.length, SIMPLE.length);
+    assert.equal(result[0], null); // first has no predecessor
+    assert.ok(Math.abs(result[1]! - 1.0) < 1e-10); // 2/1 - 1
+    assert.ok(Math.abs(result[2]! - 0.5) < 1e-10); // 3/2 - 1
+    assert.ok(Math.abs(result[3]! - (4 / 3 - 1)) < 1e-10);
+    assert.ok(Math.abs(result[4]! - 0.25) < 1e-10); // 5/4 - 1
+  });
+
+  it('returns null when current or previous value is null', () => {
+    const result = periodVariation(WITH_GAPS);
+    assert.equal(result[0], null); // first position always null
+    assert.equal(result[1], null); // gap at index 1
+    assert.equal(result[2], null); // previous (index 1) was null
+    assert.equal(result[3], null); // gap at index 3
+    assert.equal(result[4], null); // previous (index 3) was null
+  });
+
+  it('returns array of same length as input', () => {
+    assert.equal(periodVariation(SIMPLE).length, SIMPLE.length);
+  });
+
+  it('returns [null] for single-element input', () => {
+    assert.deepEqual(periodVariation([obs('01-01-2024', '1')]), [null]);
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(periodVariation([]), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// annualVariation
+// ---------------------------------------------------------------------------
+
+describe('annualVariation', () => {
+  it('calculates year-over-year fractional change with periodsPerYear offset', () => {
+    // 12 monthly obs: values 1..12, periodsPerYear=12
+    // obs[12] / obs[0] - 1 = 13/1 - 1 = 12; but we only have 12 items (indices 0-11)
+    // So indices 0-11: first 12 have null, from index 12 onward we'd have values
+    // With 5 items and periodsPerYear=5: obs[5] doesn't exist, all null except...
+    // Let's use periodsPerYear=2 with 4 items: values 2,4,6,8
+    // result[0]=null, result[1]=null, result[2]=6/2-1=2.0, result[3]=8/4-1=1.0
+    const data = [
+      obs('01-01-2024', '2'),
+      obs('02-01-2024', '4'),
+      obs('03-01-2024', '6'),
+      obs('04-01-2024', '8'),
+    ];
+    const result = annualVariation(data, 2);
+    assert.equal(result[0], null);
+    assert.equal(result[1], null);
+    assert.ok(Math.abs(result[2]! - 2.0) < 1e-10); // 6/2 - 1
+    assert.ok(Math.abs(result[3]! - 1.0) < 1e-10); // 8/4 - 1
+  });
+
+  it('returns null when the period-offset value is null', () => {
+    const data = [obs('01-01-2024', '', 'NO_OBS'), obs('02-01-2024', '4'), obs('03-01-2024', '6')];
+    const result = annualVariation(data, 1);
+    // result[0] = null (no offset)
+    // result[1] = 4/null - 1 → null (base is null)
+    // result[2] = 6/4 - 1 = 0.5
+    assert.equal(result[0], null);
+    assert.equal(result[1], null);
+    assert.ok(Math.abs(result[2]! - 0.5) < 1e-10);
+  });
+
+  it('returns array of same length as input', () => {
+    assert.equal(annualVariation(SIMPLE, 12).length, SIMPLE.length);
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(annualVariation([], 12), []);
+  });
+
+  it('throws when periodsPerYear is not a positive integer', () => {
+    assert.throws(() => annualVariation(SIMPLE, 0), /periodsPerYear/i);
+    assert.throws(() => annualVariation(SIMPLE, -1), /periodsPerYear/i);
+    assert.throws(() => annualVariation(SIMPLE, 1.5), /periodsPerYear/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rollingMean
+// ---------------------------------------------------------------------------
+
+describe('rollingMean', () => {
+  it('calculates rolling mean with full windows', () => {
+    // values 1,2,3,4,5 with window=3
+    // [null, null, (1+2+3)/3=2, (2+3+4)/3=3, (3+4+5)/3=4]
+    const result = rollingMean(SIMPLE, 3);
+    assert.equal(result[0], null);
+    assert.equal(result[1], null);
+    assert.ok(Math.abs(result[2]! - 2) < 1e-10);
+    assert.ok(Math.abs(result[3]! - 3) < 1e-10);
+    assert.ok(Math.abs(result[4]! - 4) < 1e-10);
+  });
+
+  it('returns null for window positions containing gaps', () => {
+    // values 2, null, 4, null, 6 with window=2
+    const result = rollingMean(WITH_GAPS, 2);
+    assert.equal(result[0], null); // not enough window
+    assert.equal(result[1], null); // gap
+    assert.equal(result[2], null); // window includes gap at index 1
+    assert.equal(result[3], null); // gap
+    assert.equal(result[4], null); // window includes gap at index 3
+  });
+
+  it('returns array of same length as input', () => {
+    assert.equal(rollingMean(SIMPLE, 2).length, SIMPLE.length);
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(rollingMean([], 3), []);
+  });
+
+  it('throws when window is not a positive integer', () => {
+    assert.throws(() => rollingMean(SIMPLE, 0), /window/i);
+    assert.throws(() => rollingMean(SIMPLE, -1), /window/i);
+    assert.throws(() => rollingMean(SIMPLE, 1.5), /window/i);
+  });
+
+  it('window of 1 returns the parsed values directly', () => {
+    const result = rollingMean(SIMPLE, 1);
+    assert.deepEqual(result, [1, 2, 3, 4, 5]);
+  });
+});

--- a/tests/utils/transform.test.ts
+++ b/tests/utils/transform.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { filterValid, parseValue, toArrays, toMap, toNumbers } from '../../src/utils/index.ts';
+import type { Observation } from '../../src/client/index.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function obs(indexDateString: string, value: string, statusCode = 'OK'): Observation {
+  return { indexDateString, value, statusCode };
+}
+
+const OBSERVATIONS: Observation[] = [
+  obs('01-01-2024', '1.75'),
+  obs('02-01-2024', '', 'NO_OBS'),
+  obs('03-01-2024', '1.80'),
+  obs('04-01-2024', 'N/A', 'ERR'),
+  obs('05-01-2024', '1.85'),
+];
+
+// ---------------------------------------------------------------------------
+// parseValue
+// ---------------------------------------------------------------------------
+
+describe('parseValue', () => {
+  it('parses a numeric string to a number', () => {
+    assert.equal(parseValue('1.75'), 1.75);
+  });
+
+  it('parses an integer string', () => {
+    assert.equal(parseValue('42'), 42);
+  });
+
+  it('parses a negative number string', () => {
+    assert.equal(parseValue('-3.14'), -3.14);
+  });
+
+  it('returns null for an empty string', () => {
+    assert.equal(parseValue(''), null);
+  });
+
+  it('returns null for a non-numeric string', () => {
+    assert.equal(parseValue('N/A'), null);
+  });
+
+  it('returns null for whitespace-only string', () => {
+    assert.equal(parseValue('   '), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterValid
+// ---------------------------------------------------------------------------
+
+describe('filterValid', () => {
+  it('returns only observations with parseable numeric values', () => {
+    // OBSERVATIONS: valid, gap (''), valid, non-numeric ('N/A'), valid → 3 valid
+    const result = filterValid(OBSERVATIONS);
+    assert.equal(result.length, 3);
+    assert.equal(result[0]!.indexDateString, '01-01-2024');
+    assert.equal(result[1]!.indexDateString, '03-01-2024');
+    assert.equal(result[2]!.indexDateString, '05-01-2024');
+  });
+
+  it('returns empty array when all observations have empty values', () => {
+    const all_gaps = [obs('01-01-2024', ''), obs('02-01-2024', '')];
+    assert.deepEqual(filterValid(all_gaps), []);
+  });
+
+  it('returns all observations when none have empty values', () => {
+    const valid = [obs('01-01-2024', '1.0'), obs('02-01-2024', '2.0')];
+    assert.equal(filterValid(valid).length, 2);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [obs('01-01-2024', '1.0'), obs('02-01-2024', '')];
+    filterValid(input);
+    assert.equal(input.length, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toNumbers
+// ---------------------------------------------------------------------------
+
+describe('toNumbers', () => {
+  it('converts values to numbers, nulls for empty or non-numeric', () => {
+    const result = toNumbers(OBSERVATIONS);
+    assert.deepEqual(result, [1.75, null, 1.8, null, 1.85]);
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(toNumbers([]), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toMap
+// ---------------------------------------------------------------------------
+
+describe('toMap', () => {
+  it('returns a Map keyed by indexDateString', () => {
+    const simple = [obs('01-01-2024', '1.75'), obs('02-01-2024', '')];
+    const map = toMap(simple);
+    assert.equal(map.size, 2);
+    assert.equal(map.get('01-01-2024'), 1.75);
+    assert.equal(map.get('02-01-2024'), null);
+  });
+
+  it('later duplicate dates overwrite earlier ones', () => {
+    const dupes = [obs('01-01-2024', '1.0'), obs('01-01-2024', '2.0')];
+    const map = toMap(dupes);
+    assert.equal(map.size, 1);
+    assert.equal(map.get('01-01-2024'), 2.0);
+  });
+
+  it('returns empty Map for empty input', () => {
+    assert.equal(toMap([]).size, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toArrays
+// ---------------------------------------------------------------------------
+
+describe('toArrays', () => {
+  it('returns parallel dates and values arrays', () => {
+    const input = [obs('01-01-2024', '1.75'), obs('02-01-2024', '')];
+    const { dates, values } = toArrays(input);
+    assert.equal(dates.length, 2);
+    assert.equal(values.length, 2);
+    assert.equal(dates[0]!.getUTCDate(), 1);
+    assert.equal(dates[0]!.getUTCMonth(), 0);
+    assert.equal(dates[0]!.getUTCFullYear(), 2024);
+    assert.equal(values[0], 1.75);
+    assert.equal(values[1], null);
+  });
+
+  it('returns empty arrays for empty input', () => {
+    const { dates, values } = toArrays([]);
+    assert.equal(dates.length, 0);
+    assert.equal(values.length, 0);
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New feature

## Summary
- Implements `bcch/utils` subpath module with three pure-function files:
  - `dates.ts` — `parseObservationDate` (DD-MM-YYYY → UTC Date) and `formatQueryDate` (Date → YYYY-MM-DD)
  - `transform.ts` — `parseValue`, `filterValid`, `toNumbers`, `toMap`, `toArrays`
  - `stats.ts` — `mean`, `stdDev`, `min`, `max`, `periodVariation`, `annualVariation`, `rollingMean`
- Wires `src/index.ts` to re-export all public symbols from `client`, `series`, and `utils`
- Replaces the template `hello()` test with a smoke-test for root exports
- Merges `feat/client` and `feat/series` as dependencies

## Test plan
- [x] 113 tests total across all modules
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` passes (113/113)
- [x] `npm run build` passes (clean `dist/` output)

## Changelog
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (deferred — will update before release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)