### PR TITLE
feat: add pluggable caching layer (bcchapi/cache)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,8 @@
     "URL": "readonly",
     "URLSearchParams": "readonly",
     "Response": "readonly",
-    "fetch": "readonly"
+    "fetch": "readonly",
+    "setTimeout": "readonly"
   },
   "rules": {
     "no-console": "warn",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Always run `npm run typecheck && npm run lint` after making changes.
 | Classes, interfaces, types, enums                     | `UpperCamelCase` |
 | Variables, parameters, functions, methods, properties | `lowerCamelCase` |
 | Global constants, enum values                         | `CONSTANT_CASE`  |
-| Files                                                 | `snake_case`     |
+| Files                                                 | `kebab-case`     |
 | Namespace imports                                     | `lowerCamelCase` |
 
 - Treat abbreviations as whole words: `loadHttpUrl`, not `loadHTTPURL`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const data = await client.getSeries(SERIES.PRICES.UF, {
   lastdate: '2024-12-31',
 });
 
-console.log(data.descripIng);   // "Unidad de Fomento (UF)"
+console.log(data.descripIng); // "Unidad de Fomento (UF)"
 console.log(data.observations); // [{ indexDateString, value, statusCode }, ...]
 ```
 
@@ -72,7 +72,7 @@ const yoy = annualVariation(cpi.observations, 12);
 
 ```ts
 const monthlySeries = await client.searchSeries('MONTHLY');
-console.log(monthlySeries.map(s => s.englishTitle));
+console.log(monthlySeries.map((s) => s.englishTitle));
 ```
 
 ### Error handling
@@ -102,21 +102,21 @@ try {
 
 #### `new Client(options)`
 
-| Option | Type | Description |
-| ------ | ---- | ----------- |
-| `user` | `string` | BCCH account email |
-| `pass` | `string` | BCCH account password |
+| Option  | Type           | Description                                                |
+| ------- | -------------- | ---------------------------------------------------------- |
+| `user`  | `string`       | BCCH account email                                         |
+| `pass`  | `string`       | BCCH account password                                      |
 | `fetch` | `typeof fetch` | Custom fetch implementation (optional, useful for testing) |
 
 #### `client.getSeries(seriesId, options?)`
 
 Fetches observations for a single time series.
 
-| Parameter | Type | Description |
-| --------- | ---- | ----------- |
-| `seriesId` | `string` | BCCH series identifier |
+| Parameter           | Type     | Description                                                |
+| ------------------- | -------- | ---------------------------------------------------------- |
+| `seriesId`          | `string` | BCCH series identifier                                     |
 | `options.firstdate` | `string` | Start date `"YYYY-MM-DD"` (defaults to earliest available) |
-| `options.lastdate` | `string` | End date `"YYYY-MM-DD"` (defaults to most recent) |
+| `options.lastdate`  | `string` | End date `"YYYY-MM-DD"` (defaults to most recent)          |
 
 Returns `Promise<SeriesData>`.
 
@@ -130,17 +130,17 @@ Returns `Promise<SeriesInfo[]>`.
 
 `SERIES` is a nested `as const` object of curated series IDs grouped by domain:
 
-| Group | Description |
-| ----- | ----------- |
-| `SERIES.EXCHANGE_RATE` | USD/CLP and major currency pairs |
-| `SERIES.PRICES` | UF, UTM, IVP, CPI and components |
-| `SERIES.INTEREST_RATES` | MPR, BCP/BCU sovereign bonds, PDBC rates |
-| `SERIES.MONEY` | M1, M2, M3, bank loans by type |
-| `SERIES.NATIONAL_ACCOUNTS` | Imacec and components |
-| `SERIES.EXTERNAL_SECTOR` | Current account, exports, imports, FDI |
-| `SERIES.EMPLOYMENT` | Unemployment rate, labour force, employed/unemployed |
-| `SERIES.PUBLIC_FINANCES` | Government revenue, expenditure, fiscal balance |
-| `SERIES.CAPITAL_MARKET` | IPSA, stock market capitalisation |
+| Group                      | Description                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `SERIES.EXCHANGE_RATE`     | USD/CLP and major currency pairs                     |
+| `SERIES.PRICES`            | UF, UTM, IVP, CPI and components                     |
+| `SERIES.INTEREST_RATES`    | MPR, BCP/BCU sovereign bonds, PDBC rates             |
+| `SERIES.MONEY`             | M1, M2, M3, bank loans by type                       |
+| `SERIES.NATIONAL_ACCOUNTS` | Imacec and components                                |
+| `SERIES.EXTERNAL_SECTOR`   | Current account, exports, imports, FDI               |
+| `SERIES.EMPLOYMENT`        | Unemployment rate, labour force, employed/unemployed |
+| `SERIES.PUBLIC_FINANCES`   | Government revenue, expenditure, fiscal balance      |
+| `SERIES.CAPITAL_MARKET`    | IPSA, stock market capitalisation                    |
 
 Use [si3.bcentral.cl](https://si3.bcentral.cl/siete) or `client.searchSeries()` to discover additional series IDs beyond the curated set.
 
@@ -148,29 +148,29 @@ Use [si3.bcentral.cl](https://si3.bcentral.cl/siete) or `client.searchSeries()` 
 
 #### Transform functions
 
-| Function | Description |
-| -------- | ----------- |
-| `parseValue(value)` | Parses a value string to `number \| null` (`null` for empty or non-numeric) |
-| `filterValid(observations)` | Returns only observations with parseable numeric values |
-| `toNumbers(observations)` | Maps observations to `Array<number \| null>` |
-| `toMap(observations)` | Returns a `Map<string, number \| null>` keyed by `indexDateString` |
-| `toArrays(observations)` | Returns `{ dates: Date[], values: Array<number \| null> }` |
-| `parseObservationDate(dateString)` | Parses `"DD-MM-YYYY"` to a UTC `Date` |
-| `formatQueryDate(date)` | Formats a `Date` to `"YYYY-MM-DD"` for use in `getSeries` options |
+| Function                           | Description                                                                 |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| `parseValue(value)`                | Parses a value string to `number \| null` (`null` for empty or non-numeric) |
+| `filterValid(observations)`        | Returns only observations with parseable numeric values                     |
+| `toNumbers(observations)`          | Maps observations to `Array<number \| null>`                                |
+| `toMap(observations)`              | Returns a `Map<string, number \| null>` keyed by `indexDateString`          |
+| `toArrays(observations)`           | Returns `{ dates: Date[], values: Array<number \| null> }`                  |
+| `parseObservationDate(dateString)` | Parses `"DD-MM-YYYY"` to a UTC `Date`                                       |
+| `formatQueryDate(date)`            | Formats a `Date` to `"YYYY-MM-DD"` for use in `getSeries` options           |
 
 #### Statistics functions
 
 All stats functions operate on `Observation[]` and ignore gap values (empty or non-numeric).
 
-| Function | Description |
-| -------- | ----------- |
-| `mean(observations)` | Arithmetic mean |
-| `stdDev(observations)` | Sample standard deviation (Bessel's correction) |
-| `min(observations)` | Minimum value |
-| `max(observations)` | Maximum value |
-| `periodVariation(observations)` | Period-over-period fractional change (`value[i] / value[i-1] - 1`) |
-| `annualVariation(observations, periodsPerYear)` | Year-over-year fractional change (`value[i] / value[i - n] - 1`) |
-| `rollingMean(observations, window)` | Rolling mean over a fixed window; `null` if any value in window is a gap |
+| Function                                        | Description                                                              |
+| ----------------------------------------------- | ------------------------------------------------------------------------ |
+| `mean(observations)`                            | Arithmetic mean                                                          |
+| `stdDev(observations)`                          | Sample standard deviation (Bessel's correction)                          |
+| `min(observations)`                             | Minimum value                                                            |
+| `max(observations)`                             | Maximum value                                                            |
+| `periodVariation(observations)`                 | Period-over-period fractional change (`value[i] / value[i-1] - 1`)       |
+| `annualVariation(observations, periodsPerYear)` | Year-over-year fractional change (`value[i] / value[i - n] - 1`)         |
+| `rollingMean(observations, window)`             | Rolling mean over a fixed window; `null` if any value in window is a gap |
 
 ## Releases
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "publishConfig": {
-    "access": "public"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -48,6 +45,9 @@
       "import": "./dist/cache/index.js",
       "default": "./dist/cache/index.js"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js",
       "default": "./dist/utils/index.js"
+    },
+    "./cache": {
+      "types": "./dist/cache/index.d.ts",
+      "import": "./dist/cache/index.js",
+      "default": "./dist/cache/index.js"
     }
   },
   "scripts": {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,3 @@
+export type { Cache } from './types.js';
+export { MemoryCache } from './memory-cache.js';
+export type { MemoryCacheOptions } from './memory-cache.js';

--- a/src/cache/memory-cache.ts
+++ b/src/cache/memory-cache.ts
@@ -1,0 +1,67 @@
+import type { Cache } from './types.js';
+
+interface Entry {
+  value: unknown;
+  expiresAt: number | null;
+}
+
+/**
+ * Options for {@link MemoryCache}.
+ */
+export interface MemoryCacheOptions {
+  /**
+   * Default time-to-live in milliseconds applied to every `set` call that
+   * does not provide its own `ttlMs`.
+   *
+   * When omitted, entries never expire unless a per-entry `ttlMs` is passed
+   * to `set`.
+   *
+   * @defaultValue `undefined` (no expiry)
+   */
+  defaultTtlMs?: number;
+}
+
+/**
+ * In-memory {@link Cache} implementation backed by a `Map`.
+ *
+ * Expired entries are evicted lazily on `get` — no background timers are
+ * created. Suitable for single-process use; does not persist across restarts.
+ *
+ * @example
+ * ```ts
+ * import { Client } from 'bcchapi/client';
+ * import { MemoryCache } from 'bcchapi/cache';
+ *
+ * const client = new Client({
+ *   user: 'me@example.com',
+ *   pass: 'secret',
+ *   cache: new MemoryCache({ defaultTtlMs: 60 * 60 * 1000 }), // 1 hour
+ * });
+ * ```
+ */
+export class MemoryCache implements Cache {
+  private readonly store = new Map<string, Entry>();
+  private readonly defaultTtlMs: number | undefined;
+
+  constructor(options?: MemoryCacheOptions) {
+    this.defaultTtlMs = options?.defaultTtlMs;
+  }
+
+  get(key: string): unknown {
+    const entry = this.store.get(key);
+    if (entry === undefined) {
+      return undefined;
+    }
+    if (entry.expiresAt !== null && Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: unknown, ttlMs?: number): void {
+    const effectiveTtl = ttlMs ?? this.defaultTtlMs;
+    const expiresAt = effectiveTtl !== undefined ? Date.now() + effectiveTtl : null;
+    this.store.set(key, { value, expiresAt });
+  }
+}

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,0 +1,44 @@
+/**
+ * A minimal cache interface for storing and retrieving API responses.
+ *
+ * Implement this interface to plug in any caching backend (in-memory, Redis,
+ * SQLite, etc.) into {@link https://github.com/airarrazaval/bcchapi | Client}.
+ *
+ * @example
+ * ```ts
+ * import type { Cache } from 'bcchapi/cache';
+ * import { createClient } from 'redis';
+ *
+ * const redis = await createClient().connect();
+ *
+ * const redisCache: Cache = {
+ *   get: async (key) => {
+ *     const raw = await redis.get(key);
+ *     return raw === null ? undefined : JSON.parse(raw);
+ *   },
+ *   set: async (key, value, ttlMs) => {
+ *     const opts = ttlMs !== undefined ? { PX: ttlMs } : {};
+ *     await redis.set(key, JSON.stringify(value), opts);
+ *   },
+ * };
+ * ```
+ */
+export interface Cache {
+  /**
+   * Returns the cached value for `key`, or `undefined` on a miss.
+   *
+   * @param key - Cache key.
+   * @returns The stored value, or `undefined` if the key is absent or expired.
+   */
+  get(key: string): unknown;
+
+  /**
+   * Stores `value` under `key` with an optional time-to-live.
+   *
+   * @param key - Cache key.
+   * @param value - Value to store.
+   * @param ttlMs - Optional time-to-live in milliseconds. Implementations may
+   *   ignore this if TTL is managed externally (e.g. Redis `EXPIRE`).
+   */
+  set(key: string, value: unknown, ttlMs?: number): void;
+}

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,6 @@
 import { ApiError, HttpError } from './types.js';
 import type {
+  Cache,
   ClientOptions,
   Frequency,
   GetSeriesOptions,
@@ -65,11 +66,15 @@ export class Client {
   private readonly user: string;
   private readonly pass: string;
   private readonly fetch: typeof globalThis.fetch;
+  private readonly cache: Cache | undefined;
+  private readonly cacheTtlMs: number | undefined;
 
   constructor(options: ClientOptions) {
     this.user = options.user;
     this.pass = options.pass;
     this.fetch = options.fetch ?? globalThis.fetch;
+    this.cache = options.cache;
+    this.cacheTtlMs = options.cacheTtlMs;
   }
 
   /**
@@ -92,6 +97,15 @@ export class Client {
    * ```
    */
   async getSeries(seriesId: string, options?: GetSeriesOptions): Promise<SeriesData> {
+    const cacheKey = `getSeries:${seriesId}:${options?.firstdate ?? ''}:${options?.lastdate ?? ''}`;
+
+    if (this.cache !== undefined) {
+      const cached = this.cache.get(cacheKey);
+      if (cached !== undefined) {
+        return cached as SeriesData;
+      }
+    }
+
     const params = this.baseParams();
     params.set('function', 'GetSeries');
     params.set('timeseries', seriesId);
@@ -114,12 +128,15 @@ export class Client {
       statusCode: obs.statusCode,
     }));
 
-    return {
+    const result: SeriesData = {
       seriesId: raw.Series.seriesId,
       descripEsp: raw.Series.descripEsp,
       descripIng: raw.Series.descripIng,
       observations,
     };
+
+    this.cache?.set(cacheKey, result, this.cacheTtlMs);
+    return result;
   }
 
   /**
@@ -138,6 +155,15 @@ export class Client {
    * ```
    */
   async searchSeries(frequency: Frequency): Promise<SeriesInfo[]> {
+    const cacheKey = `searchSeries:${frequency}`;
+
+    if (this.cache !== undefined) {
+      const cached = this.cache.get(cacheKey);
+      if (cached !== undefined) {
+        return cached as SeriesInfo[];
+      }
+    }
+
     const params = this.baseParams();
     params.set('function', 'SearchSeries');
     params.set('frequency', frequency);
@@ -148,7 +174,7 @@ export class Client {
       throw new ApiError(`BCCH API error: ${raw.Descripcion}`, raw.Codigo, raw.Descripcion);
     }
 
-    return (raw.SeriesInfos ?? []).map((info) => ({
+    const result: SeriesInfo[] = (raw.SeriesInfos ?? []).map((info) => ({
       seriesId: info.seriesId,
       frequencyCode: info.frequencyCode,
       spanishTitle: info.spanishTitle,
@@ -158,6 +184,9 @@ export class Client {
       updatedAt: info.updatedAt,
       createdAt: info.createdAt,
     }));
+
+    this.cache?.set(cacheKey, result, this.cacheTtlMs);
+    return result;
   }
 
   private baseParams(): URLSearchParams {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,7 @@
 export { Client } from './client.js';
 export { ApiError, HttpError } from './types.js';
 export type {
+  Cache,
   ClientOptions,
   Frequency,
   GetSeriesOptions,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,5 @@
+import type { Cache } from '../cache/types.js';
+
 /**
  * Credentials and configuration for {@link Client}.
  */
@@ -17,7 +19,35 @@ export interface ClientOptions {
    * @defaultValue `globalThis.fetch`
    */
   fetch?: typeof globalThis.fetch;
+
+  /**
+   * Optional cache backend for storing API responses.
+   *
+   * Any object implementing the {@link Cache} interface is accepted — use
+   * `MemoryCache` from `bcchapi/cache` for a zero-config in-memory option,
+   * or provide your own adapter (Redis, SQLite, etc.).
+   *
+   * When omitted, every call makes a fresh HTTP request.
+   *
+   * @example
+   * ```ts
+   * import { MemoryCache } from 'bcchapi/cache';
+   * const client = new Client({ user, pass, cache: new MemoryCache() });
+   * ```
+   */
+  cache?: Cache;
+
+  /**
+   * Time-to-live in milliseconds passed to `cache.set` on every successful
+   * response. Applies to both `getSeries` and `searchSeries`.
+   *
+   * When omitted, `cache.set` is called without a TTL argument and expiry is
+   * determined by the cache implementation.
+   */
+  cacheTtlMs?: number;
 }
+
+export type { Cache } from '../cache/types.js';
 
 /**
  * A single observation returned by the BCCH API.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { Client, ApiError, HttpError } from './client/index.js';
 export type {
+  Cache,
   ClientOptions,
   Frequency,
   GetSeriesOptions,
@@ -7,6 +8,9 @@ export type {
   SeriesData,
   SeriesInfo,
 } from './client/index.js';
+
+export { MemoryCache } from './cache/index.js';
+export type { MemoryCacheOptions } from './cache/index.js';
 
 export { SERIES } from './series/index.js';
 

--- a/tests/cache/cache.test.ts
+++ b/tests/cache/cache.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { MemoryCache } from '../../src/cache/index.ts';
+import type { Cache } from '../../src/cache/index.ts';
+
+describe('Cache interface', () => {
+  it('MemoryCache satisfies the Cache interface', () => {
+    const cache: Cache = new MemoryCache();
+    assert.ok(typeof cache.get === 'function');
+    assert.ok(typeof cache.set === 'function');
+  });
+});
+
+describe('MemoryCache', () => {
+  describe('get / set', () => {
+    it('returns undefined for a missing key', () => {
+      const cache = new MemoryCache();
+      assert.equal(cache.get('missing'), undefined);
+    });
+
+    it('returns the stored value for a known key', () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'value');
+      assert.equal(cache.get('key'), 'value');
+    });
+
+    it('stores and retrieves objects', () => {
+      const cache = new MemoryCache();
+      const obj = { seriesId: 'F073.UFF.PRE.Z.D', observations: [] };
+      cache.set('key', obj);
+      assert.deepEqual(cache.get('key'), obj);
+    });
+
+    it('overwrites an existing entry', () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'first');
+      cache.set('key', 'second');
+      assert.equal(cache.get('key'), 'second');
+    });
+
+    it('stores multiple keys independently', () => {
+      const cache = new MemoryCache();
+      cache.set('a', 1);
+      cache.set('b', 2);
+      assert.equal(cache.get('a'), 1);
+      assert.equal(cache.get('b'), 2);
+    });
+  });
+
+  describe('TTL — per-entry', () => {
+    it('returns the value before TTL expires', () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'value', 60_000);
+      assert.equal(cache.get('key'), 'value');
+    });
+
+    it('returns undefined after per-entry TTL expires', async () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'value', 10);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(cache.get('key'), undefined);
+    });
+
+    it('evicts expired entry lazily on get', async () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'value', 10);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      // First get evicts
+      assert.equal(cache.get('key'), undefined);
+      // Second get still returns undefined (not re-stored)
+      assert.equal(cache.get('key'), undefined);
+    });
+  });
+
+  describe('TTL — defaultTtlMs', () => {
+    it('applies defaultTtlMs when no per-entry TTL is given', async () => {
+      const cache = new MemoryCache({ defaultTtlMs: 10 });
+      cache.set('key', 'value');
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(cache.get('key'), undefined);
+    });
+
+    it('per-entry ttlMs overrides defaultTtlMs', async () => {
+      const cache = new MemoryCache({ defaultTtlMs: 10 });
+      cache.set('key', 'value', 60_000);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(cache.get('key'), 'value');
+    });
+
+    it('entries never expire when no TTL is configured', () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'value');
+      assert.equal(cache.get('key'), 'value');
+    });
+  });
+});

--- a/tests/client/client.test.ts
+++ b/tests/client/client.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { ApiError, Client, HttpError } from '../../src/client/index.ts';
+import type { Cache } from '../../src/cache/index.ts';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -369,5 +370,182 @@ describe('Client.searchSeries', () => {
         return true;
       },
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client — caching (getSeries)
+// ---------------------------------------------------------------------------
+
+function makeCache(): Cache & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    get: (key) => store.get(key),
+    set: (key, value) => { store.set(key, value); },
+  };
+}
+
+describe('Client.getSeries — caching', () => {
+  it('stores the result in the cache on a miss', async () => {
+    const cache = makeCache();
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_GET_SERIES_RESPONSE),
+      cache,
+    });
+
+    const data = await client.getSeries(SERIES_ID);
+    assert.equal(cache.store.size, 1);
+    assert.deepEqual(cache.store.get(`getSeries:${SERIES_ID}::`), data);
+  });
+
+  it('returns the cached value on a hit without making an HTTP call', async () => {
+    const cache = makeCache();
+    let fetchCalls = 0;
+    const countingFetch: typeof globalThis.fetch = async () => {
+      fetchCalls++;
+      return new Response(JSON.stringify(MOCK_GET_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: countingFetch, cache });
+
+    await client.getSeries(SERIES_ID);
+    assert.equal(fetchCalls, 1);
+
+    await client.getSeries(SERIES_ID);
+    assert.equal(fetchCalls, 1);
+  });
+
+  it('uses a cache key that includes firstdate and lastdate', async () => {
+    const cache = makeCache();
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_GET_SERIES_RESPONSE),
+      cache,
+    });
+
+    await client.getSeries(SERIES_ID, { firstdate: '2024-01-01', lastdate: '2024-12-31' });
+    assert.ok(cache.store.has(`getSeries:${SERIES_ID}:2024-01-01:2024-12-31`));
+  });
+
+  it('treats calls with different date ranges as separate cache entries', async () => {
+    const cache = makeCache();
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_GET_SERIES_RESPONSE),
+      cache,
+    });
+
+    await client.getSeries(SERIES_ID, { firstdate: '2024-01-01' });
+    await client.getSeries(SERIES_ID, { firstdate: '2023-01-01' });
+    assert.equal(cache.store.size, 2);
+  });
+
+  it('passes cacheTtlMs to cache.set', async () => {
+    const ttlsReceived: Array<number | undefined> = [];
+    const cache: Cache = {
+      get: () => undefined,
+      set: (_key, _value, ttlMs) => { ttlsReceived.push(ttlMs); },
+    };
+
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_GET_SERIES_RESPONSE),
+      cache,
+      cacheTtlMs: 60_000,
+    });
+
+    await client.getSeries(SERIES_ID);
+    assert.deepEqual(ttlsReceived, [60_000]);
+  });
+
+  it('does not cache errors — a subsequent call retries the HTTP request', async () => {
+    const cache = makeCache();
+    let fetchCalls = 0;
+    const failThenSucceed: typeof globalThis.fetch = async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        return new Response('error', { status: 503 });
+      }
+      return new Response(JSON.stringify(MOCK_GET_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: failThenSucceed, cache });
+
+    await assert.rejects(() => client.getSeries(SERIES_ID));
+    assert.equal(cache.store.size, 0);
+
+    await client.getSeries(SERIES_ID);
+    assert.equal(fetchCalls, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client — caching (searchSeries)
+// ---------------------------------------------------------------------------
+
+describe('Client.searchSeries — caching', () => {
+  it('stores the result in the cache on a miss', async () => {
+    const cache = makeCache();
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_SEARCH_SERIES_RESPONSE),
+      cache,
+    });
+
+    const infos = await client.searchSeries('DAILY');
+    assert.equal(cache.store.size, 1);
+    assert.deepEqual(cache.store.get('searchSeries:DAILY'), infos);
+  });
+
+  it('returns the cached value on a hit without making an HTTP call', async () => {
+    const cache = makeCache();
+    let fetchCalls = 0;
+    const countingFetch: typeof globalThis.fetch = async () => {
+      fetchCalls++;
+      return new Response(JSON.stringify(MOCK_SEARCH_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: countingFetch, cache });
+
+    await client.searchSeries('MONTHLY');
+    assert.equal(fetchCalls, 1);
+
+    await client.searchSeries('MONTHLY');
+    assert.equal(fetchCalls, 1);
+  });
+
+  it('treats different frequencies as separate cache entries', async () => {
+    const cache = makeCache();
+    const client = new Client({
+      ...makeCredentials(),
+      fetch: makeFetch(MOCK_SEARCH_SERIES_RESPONSE),
+      cache,
+    });
+
+    await client.searchSeries('DAILY');
+    await client.searchSeries('MONTHLY');
+    assert.equal(cache.store.size, 2);
+  });
+
+  it('does not cache errors — a subsequent call retries the HTTP request', async () => {
+    const cache = makeCache();
+    let fetchCalls = 0;
+    const failThenSucceed: typeof globalThis.fetch = async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        return new Response('error', { status: 503 });
+      }
+      return new Response(JSON.stringify(MOCK_SEARCH_SERIES_RESPONSE));
+    };
+
+    const client = new Client({ ...makeCredentials(), fetch: failThenSucceed, cache });
+
+    await assert.rejects(() => client.searchSeries('DAILY'));
+    assert.equal(cache.store.size, 0);
+
+    await client.searchSeries('DAILY');
+    assert.equal(fetchCalls, 2);
   });
 });

--- a/tests/client/client.test.ts
+++ b/tests/client/client.test.ts
@@ -382,7 +382,9 @@ function makeCache(): Cache & { store: Map<string, unknown> } {
   return {
     store,
     get: (key) => store.get(key),
-    set: (key, value) => { store.set(key, value); },
+    set: (key, value) => {
+      store.set(key, value);
+    },
   };
 }
 
@@ -446,7 +448,9 @@ describe('Client.getSeries — caching', () => {
     const ttlsReceived: Array<number | undefined> = [];
     const cache: Cache = {
       get: () => undefined,
-      set: (_key, _value, ttlMs) => { ttlsReceived.push(ttlMs); },
+      set: (_key, _value, ttlMs) => {
+        ttlsReceived.push(ttlMs);
+      },
     };
 
     const client = new Client({


### PR DESCRIPTION
## Summary

- New `bcchapi/cache` subpath exports a minimal `Cache` interface and a built-in `MemoryCache` (Map-backed, lazy TTL eviction, no background timers)
- `ClientOptions` gains optional `cache?: Cache` and `cacheTtlMs?: number` — omitting them preserves existing behaviour exactly
- Cache hits skip the HTTP request; errors are never cached so failed calls always retry
- `Cache` type re-exported from `bcchapi/client` so adapter authors don't need to import from `bcchapi/cache`
- File naming convention updated to `kebab-case` in `AGENTS.md`

## Test plan

- [x] `MemoryCache` — get/set, TTL per-entry, `defaultTtlMs`, lazy eviction
- [x] `Client.getSeries` — cache miss stores result, cache hit skips fetch, key encodes series ID + dates, `cacheTtlMs` forwarded, errors not cached
- [x] `Client.searchSeries` — same coverage as above
- [x] `npm run typecheck && npm run lint && npm test` all pass (135 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)