### PR TITLE
chore: upgrade typescript to 5.9.3 and document series catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,7 +706,7 @@ Quick-reference checklist. Full rules for each step are in the sections above.
 - [ ] **Green** — write minimum `src/` code to pass tests; use `npm run dev` for watch mode
 - [ ] **Refactor** — clean up with tests staying green; run `npm test`
 - [ ] **Validate** — `npm run format && npm run check`; fix any remaining issues with `npm run lint:fix`
-- [ ] **Commit** — `git commit -m "feat: description"` (→ [Commits](#commits))
+- [ ] **Commit** — stage `package-lock.json` too if any dependency changed (`npm install` must be re-run after editing `package.json`); then `git commit -m "feat: description"` (→ [Commits](#commits))
 - [ ] Repeat **Red → Green → Refactor → Validate → Commit** for each requirement
 
 ### Pull Request
@@ -726,7 +726,7 @@ Quick-reference checklist. Full rules for each step are in the sections above.
 - [ ] `git checkout main && git pull`
 - [ ] Review `README.md` — ensure it reflects all new or changed public API introduced since the last release
 - [ ] `npm run changelog` — regenerates `CHANGELOG.md` from commits; review the output (→ [Updating the Changelog](#updating-the-changelog))
-- [ ] `git add README.md CHANGELOG.md && git commit -m "chore: release vX.Y.Z"` (use the version printed by git-cliff)
+- [ ] `git add README.md CHANGELOG.md && git commit -m "chore: release vX.Y.Z"` (use the version printed by git-cliff; also stage `package-lock.json` if any dependency was updated since the last release)
 - [ ] `npm version patch` (or `minor` / `major` — must match the version git-cliff determined)
 - [ ] `npm pack --dry-run` — verify published contents (→ [Verifying Package Contents](#verifying-package-contents))
 - [ ] `git push --follow-tags` — the `publish` workflow triggers automatically; do not run `npm publish` manually

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Built-in in-memory cache. Entries are evicted lazily on `get` — no background 
 | `SERIES.PUBLIC_FINANCES`   | Government revenue, expenditure, fiscal balance      |
 | `SERIES.CAPITAL_MARKET`    | IPSA, stock market capitalisation                    |
 
-Use [si3.bcentral.cl](https://si3.bcentral.cl/siete) or `client.searchSeries()` to discover additional series IDs beyond the curated set.
+The curated set covers the most frequently queried series. The complete catalog of over 22,000 series is available as a [downloadable spreadsheet](https://si3.bcentral.cl/estadisticas/Principal1/Web_Services/Webservices/series.xlsx) from the BCCH. You can also use [si3.bcentral.cl](https://si3.bcentral.cl/siete) or `client.searchSeries()` to browse and discover additional series IDs.
 
 ### `bcchapi/utils`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bcchapi",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bcchapi",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.12.0",
@@ -15,7 +15,7 @@
         "oxlint": "^1.51.0",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.17",
-        "typescript": "^5.8.0"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -1906,6 +1906,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "oxlint": "^1.51.0",
     "tsx": "^4.21.0",
     "typedoc": "^0.28.17",
-    "typescript": "^5.8.0"
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/src/series/series.ts
+++ b/src/series/series.ts
@@ -2,7 +2,10 @@
  * Curated constants for commonly used BCCH series identifiers.
  *
  * This is not an exhaustive catalog — it covers the most frequently queried
- * series across key macroeconomic domains. Use {@link https://si3.bcentral.cl/siete | si3.bcentral.cl}
+ * series across key macroeconomic domains. The complete list of over 22,000
+ * series is available as a downloadable spreadsheet from the
+ * {@link https://si3.bcentral.cl/estadisticas/Principal1/Web_Services/Webservices/series.xlsx | BCCH series catalog (xlsx)}.
+ * You can also use {@link https://si3.bcentral.cl/siete | si3.bcentral.cl}
  * or {@link Client.searchSeries} to discover additional series IDs.
  *
  * @example


### PR DESCRIPTION
## Summary

- Bump `typescript` devDependency from `^5.8.0` to `^5.9.3`
- Add link to the [BCCH full series catalog (xlsx)](https://si3.bcentral.cl/estadisticas/Principal1/Web_Services/Webservices/series.xlsx) in both the `SERIES` JSDoc and the README, making it clear the curated set is a subset of 22,000+ available series
- Document `package-lock.json` commit requirement in AGENTS.md to prevent it from being left uncommitted after dependency updates

## Test plan

- [x] All 146 tests pass with TypeScript 5.9.3 (`npm run check`)
- [x] No type errors introduced by the compiler upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)