### PR TITLE
feat!: async Cache interface, clear(), and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,19 @@ const client = new Client({
 const data = await client.getSeries(SERIES.PRICES.UF);
 ```
 
-Bring your own backend by implementing the `Cache` interface:
+Bring your own backend by implementing the `Cache` interface. Methods may return values or promises, so both synchronous and asynchronous backends are supported:
 
 ```ts
 import type { Cache } from 'bcchapi/cache';
 
 const redisCache: Cache = {
-  get: (key) => {
+  get: async (key) => {
     /* ... */
   },
-  set: (key, value, ttlMs) => {
+  set: async (key, value, ttlMs) => {
+    /* ... */
+  },
+  clear: async () => {
     /* ... */
   },
 };
@@ -170,12 +173,13 @@ Returns `Promise<SeriesInfo[]>`.
 
 #### `Cache` interface
 
-Minimal interface for plugging in any cache backend:
+Minimal interface for plugging in any cache backend. Methods may return values or promises:
 
 ```ts
 interface Cache {
-  get(key: string): unknown;
-  set(key: string, value: unknown, ttlMs?: number): void;
+  get(key: string): unknown | Promise<unknown>;
+  set(key: string, value: unknown, ttlMs?: number): void | Promise<void>;
+  clear(): void | Promise<void>;
 }
 ```
 

--- a/src/cache/memory-cache.ts
+++ b/src/cache/memory-cache.ts
@@ -64,4 +64,8 @@ export class MemoryCache implements Cache {
     const expiresAt = effectiveTtl !== undefined ? Date.now() + effectiveTtl : null;
     this.store.set(key, { value, expiresAt });
   }
+
+  clear(): void {
+    this.store.clear();
+  }
 }

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,8 +1,10 @@
 /**
  * A minimal cache interface for storing and retrieving API responses.
  *
- * Implement this interface to plug in any caching backend (in-memory, Redis,
- * SQLite, etc.) into {@link https://github.com/airarrazaval/bcchapi | Client}.
+ * Methods may return values or promises, allowing both synchronous (in-memory)
+ * and asynchronous (Redis, SQLite, HTTP) implementations. The
+ * {@link https://github.com/airarrazaval/bcchapi | Client} always `await`s
+ * cache calls, so synchronous implementations work without wrapping.
  *
  * @example
  * ```ts
@@ -20,6 +22,9 @@
  *     const opts = ttlMs !== undefined ? { PX: ttlMs } : {};
  *     await redis.set(key, JSON.stringify(value), opts);
  *   },
+ *   clear: async () => {
+ *     await redis.flushDb();
+ *   },
  * };
  * ```
  */
@@ -30,7 +35,7 @@ export interface Cache {
    * @param key - Cache key.
    * @returns The stored value, or `undefined` if the key is absent or expired.
    */
-  get(key: string): unknown;
+  get(key: string): unknown | Promise<unknown>;
 
   /**
    * Stores `value` under `key` with an optional time-to-live.
@@ -40,5 +45,12 @@ export interface Cache {
    * @param ttlMs - Optional time-to-live in milliseconds. Implementations may
    *   ignore this if TTL is managed externally (e.g. Redis `EXPIRE`).
    */
-  set(key: string, value: unknown, ttlMs?: number): void;
+  set(key: string, value: unknown, ttlMs?: number): void | Promise<void>;
+
+  /**
+   * Removes all entries from the cache.
+   *
+   * Implementations should evict every stored key, regardless of TTL.
+   */
+  clear(): void | Promise<void>;
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -53,7 +53,7 @@ interface RawSearchSeriesResponse {
  *
  * @example
  * ```ts
- * import { Client } from 'bcch/client';
+ * import { Client } from 'bcchapi/client';
  *
  * const client = new Client({ user: 'me@example.com', pass: 'secret' });
  * const data = await client.getSeries('F022.TPM.TIN.D001.NO.Z.D', {
@@ -100,7 +100,7 @@ export class Client {
     const cacheKey = `getSeries:${seriesId}:${options?.firstdate ?? ''}:${options?.lastdate ?? ''}`;
 
     if (this.cache !== undefined) {
-      const cached = this.cache.get(cacheKey);
+      const cached = await this.cache.get(cacheKey);
       if (cached !== undefined) {
         return cached as SeriesData;
       }
@@ -135,7 +135,7 @@ export class Client {
       observations,
     };
 
-    this.cache?.set(cacheKey, result, this.cacheTtlMs);
+    await this.cache?.set(cacheKey, result, this.cacheTtlMs);
     return result;
   }
 
@@ -158,7 +158,7 @@ export class Client {
     const cacheKey = `searchSeries:${frequency}`;
 
     if (this.cache !== undefined) {
-      const cached = this.cache.get(cacheKey);
+      const cached = await this.cache.get(cacheKey);
       if (cached !== undefined) {
         return cached as SeriesInfo[];
       }
@@ -185,7 +185,7 @@ export class Client {
       createdAt: info.createdAt,
     }));
 
-    this.cache?.set(cacheKey, result, this.cacheTtlMs);
+    await this.cache?.set(cacheKey, result, this.cacheTtlMs);
     return result;
   }
 

--- a/src/series/series.ts
+++ b/src/series/series.ts
@@ -10,8 +10,8 @@
  *
  * @example
  * ```ts
- * import { Client } from 'bcch/client';
- * import { SERIES } from 'bcch/series';
+ * import { Client } from 'bcchapi/client';
+ * import { SERIES } from 'bcchapi/series';
  *
  * const client = new Client({ user: '...', pass: '...' });
  * const data = await client.getSeries(SERIES.PRICES.UF);

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -33,9 +33,6 @@ export function parseObservationDate(dateString: string): Date {
     !Number.isInteger(day) ||
     !Number.isInteger(month) ||
     !Number.isInteger(year) ||
-    isNaN(day) ||
-    isNaN(month) ||
-    isNaN(year) ||
     month < 1 ||
     month > 12 ||
     day < 1 ||

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -74,7 +74,11 @@ export function min(observations: Observation[]): number {
   if (values.length === 0) {
     throw new Error('No valid observations to compute min');
   }
-  return Math.min(...values);
+  let result = values[0]!;
+  for (let i = 1; i < values.length; i++) {
+    if (values[i]! < result) result = values[i]!;
+  }
+  return result;
 }
 
 /**
@@ -94,7 +98,11 @@ export function max(observations: Observation[]): number {
   if (values.length === 0) {
     throw new Error('No valid observations to compute max');
   }
-  return Math.max(...values);
+  let result = values[0]!;
+  for (let i = 1; i < values.length; i++) {
+    if (values[i]! > result) result = values[i]!;
+  }
+  return result;
 }
 
 /**

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -32,7 +32,8 @@ export function fillForward(observations: Observation[]): Observation[] {
 
   let lastValue = observations[0]!.value;
   return observations.map((obs) => {
-    if (parseValue(obs.value) !== null) {
+    const parsed = parseValue(obs.value);
+    if (parsed !== null) {
       lastValue = obs.value;
       return obs;
     }

--- a/tests/cache/cache.test.ts
+++ b/tests/cache/cache.test.ts
@@ -8,6 +8,7 @@ describe('Cache interface', () => {
     const cache: Cache = new MemoryCache();
     assert.ok(typeof cache.get === 'function');
     assert.ok(typeof cache.set === 'function');
+    assert.ok(typeof cache.clear === 'function');
   });
 });
 
@@ -91,6 +92,25 @@ describe('MemoryCache', () => {
       const cache = new MemoryCache();
       cache.set('key', 'value');
       assert.equal(cache.get('key'), 'value');
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all entries', () => {
+      const cache = new MemoryCache();
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.clear();
+      assert.equal(cache.get('a'), undefined);
+      assert.equal(cache.get('b'), undefined);
+    });
+
+    it('allows new entries after clearing', () => {
+      const cache = new MemoryCache();
+      cache.set('key', 'old');
+      cache.clear();
+      cache.set('key', 'new');
+      assert.equal(cache.get('key'), 'new');
     });
   });
 });

--- a/tests/client/client.test.ts
+++ b/tests/client/client.test.ts
@@ -385,6 +385,9 @@ function makeCache(): Cache & { store: Map<string, unknown> } {
     set: (key, value) => {
       store.set(key, value);
     },
+    clear: () => {
+      store.clear();
+    },
   };
 }
 
@@ -451,6 +454,7 @@ describe('Client.getSeries — caching', () => {
       set: (_key, _value, ttlMs) => {
         ttlsReceived.push(ttlMs);
       },
+      clear: () => {},
     };
 
     const client = new Client({


### PR DESCRIPTION
## Summary

- **fix(stats):** Replace `Math.min(...values)` / `Math.max(...values)` with loops to prevent `RangeError` on large datasets (>100k observations)
- **feat!(cache):** Make `Cache` interface async-compatible (`get` returns `unknown | Promise<unknown>`, `set` returns `void | Promise<void>`) and add required `clear()` method — enables Redis, SQLite, and other async backends. Client now `await`s all cache calls.
- **refactor(utils):** Remove redundant `isNaN` checks after `Number.isInteger` in `parseObservationDate`; avoid double `parseValue` call in `fillForward`
- **fix(docs):** Standardize all JSDoc import paths from `bcch/` to `bcchapi/` to match published package name

### BREAKING CHANGE

`Cache` interface now requires a `clear()` method and method signatures changed to support async returns. Existing `Cache` implementations must add `clear()` and may optionally return promises from `get`/`set`.

## Test plan

- [x] All 148 existing tests pass
- [x] New tests for `MemoryCache.clear()` (removes all entries, allows new entries after clearing)
- [x] Updated mock cache in client tests to satisfy new `Cache` interface
- [x] `npm run check` passes (typecheck + lint + test)
- [x] `npm run format` applied


🤖 Generated with [Claude Code](https://claude.com/claude-code)